### PR TITLE
Updated default Azure OpenAI API version to latest GA and attribute rename

### DIFF
--- a/code/config/config.py
+++ b/code/config/config.py
@@ -118,7 +118,7 @@ class AppConfig:
                 api_endpoint = self._get_config_value(cfg.get("api_endpoint_env"))
                 api_version = self._get_config_value(cfg.get("api_version_env"))
                 embedding_model = self._get_config_value(cfg.get("embedding_model_env"))
-                azure_embedding_api_version = self._get_config_value(cfg.get("azure-embedding-api-version"))
+                azure_embedding_api_version = self._get_config_value(cfg.get("azure_embedding_api_version"))
 
                 # Create the provider config
                 self.providers[name] = ProviderConfig(

--- a/code/config/config_llm.yaml
+++ b/code/config/config_llm.yaml
@@ -27,7 +27,7 @@ providers:
     api_endpoint_env: AZURE_OPENAI_ENDPOINT
     api_version_env: "2024-12-01-preview"
     embedding_model_env: text-embedding-3-small
-    azure-embedding-api-version: "2024-02-01"
+    azure_embedding_api_version: "2024-10-21"
     models:
       high: gpt-4.1
       low: gpt-4.1-mini

--- a/code/llm/azure_oai.py
+++ b/code/llm/azure_oai.py
@@ -45,7 +45,7 @@ def get_azure_openai_api_version():
         api_version = provider_config.api_version
         return api_version
     # Default value if not found in config
-    default_version = "2024-02-01"
+    default_version = "2024-10-21"
     return default_version
 
 def get_azure_openai_embedding_model():


### PR DESCRIPTION
Updated default Azure OpenAI API version to latest GA which is 2024-10-21, and changed config attribute from hyphen to underscore for consistency