### PR TITLE
Update openai provider config keys

### DIFF
--- a/code/llm/llm.py
+++ b/code/llm/llm.py
@@ -137,7 +137,7 @@ async def get_embedding(
         if provider == "openai":
             logger.debug("Getting OpenAI embeddings")
             from llm.openai import get_openai_embeddings as openai_embed
-            result = await openai_embed(text, model=model_id)
+            result = await openai_embed(text)
             logger.debug(f"OpenAI embeddings received, dimension: {len(result)}")
             return result
 

--- a/code/llm/openai.py
+++ b/code/llm/openai.py
@@ -37,11 +37,15 @@ def get_openai_api_key() -> str:
     # Get the API key from the preferred provider config
     preferred_provider = CONFIG.preferred_provider
     provider_config = CONFIG.providers[preferred_provider]
-    api_key_env_var = provider_config.api_key_env
-    
-    key = os.getenv(api_key_env_var)
+
+    key = None
+    if provider_config and provider_config.api_key:
+        api_key = provider_config.api_key
+        if api_key:
+            api_key = api_key.strip('"')  # Remove quotes if present
+            key = api_key
     if not key:
-        raise ConfigurationError(f"{api_key_env_var} is not set")
+        raise ConfigurationError(f"API key is not set")
     return key
 
 _client_lock = threading.Lock()
@@ -137,7 +141,7 @@ async def get_openai_embeddings(
     if model is None:
         preferred_provider = CONFIG.preferred_provider
         provider_config = CONFIG.providers[preferred_provider]
-        embedding_model_env_var = provider_config.embedding_model_env
+        embedding_model_env_var = provider_config.embedding_model
         
         if embedding_model_env_var:
             model = os.getenv(embedding_model_env_var)


### PR DESCRIPTION
This PR fixes the `openai` provider config to use the expected variables for `api_key` and `embedding_model`.