### PR TITLE
feat: Qdrant retriever

### DIFF
--- a/code/.env.template
+++ b/code/.env.template
@@ -9,10 +9,14 @@
 # for step-by-step details.
 
 AZURE_VECTOR_SEARCH_ENDPOINT="https://TODO.search.windows.net" 
-AZURE_VECTOR_SEARCH_API_KEY="TODO"
+AZURE_VECTOR_SEARCH_API_KEY="<TODO>"
 
 AZURE_OPENAI_ENDPOINT="https://TODO.openai.azure.com/"
-AZURE_OPENAI_API_KEY="TODO"
+AZURE_OPENAI_API_KEY="<TODO>"
 
 OPENAI_ENDPOINT="https://api.openai.com/v1/chat/completions"
-OPENAI_API_KEY="TODO"
+OPENAI_API_KEY="<TODO>"
+
+# IF USING QDRANT FOR RETRIEVAL
+QDRANT_URL="http://localhost:6333"
+QDRANT_API_KEY="<OPTIONAL>"

--- a/code/README.md
+++ b/code/README.md
@@ -11,8 +11,11 @@ code/
 ├── baseHandler.py          # Request handler
 ├── state.py                # State management
 ├── mllm.py                 # ML/LLM integration (modified for Azure)
-├── retriever.py            # Data retrieval
-├── azure_retrieve.py       # Azure AI Search integration
+├── retrieval/              # Static files directory
+|   ├── retriever.py        # Data retrieval
+|   ├── milvus_retrieve.py  # Milvus vector database integration
+|   ├── azure_retrieve.py   # Azure AI Search integration
+|   └── qdrant_retrieve.py  # Qdrant vector database integration
 ├── analyze_query.py        # Query analysis
 ├── decontextualize.py      # Query decontextualization
 ├── fastTrack.py            # Fast tracking
@@ -157,6 +160,48 @@ Azure App Service provides diagnostic tools in the Azure Portal:
 
 ### Health Check
 The application includes a health endpoint at `/health` that returns a JSON response indicating service health.
+
+## Vector Database Support
+
+NLWeb supports multiple vector database backends for semantic search. Configuration options are available at `config_retrieval.yaml`.
+
+### Azure AI Search
+
+```yaml
+azure_ai_search_1:
+  api_key_env: AZURE_VECTOR_SEARCH_API_KEY
+  api_endpoint_env: AZURE_VECTOR_SEARCH_ENDPOINT
+  index_name: embeddings1536
+  db_type: azure_ai_search
+```
+
+### Milvus
+
+```yaml
+milvus_1:
+  database_path: ../milvus/milvus_prod.db
+  index_name: prod_collection
+  db_type: milvus
+```
+
+### Qdrant
+
+```yaml
+qdrant:
+  # To connect to a Qdrant server, set the `QDRANT_URL` and optionally `QDRANT_API_KEY`.
+  # > docker run -p 6333:6333 qdrant/qdrant
+  # QDRANT_URL="http://localhost:6333"
+  api_endpoint_env: QDRANT_URL
+  api_key_env: QDRANT_API_KEY
+
+  # To use a local persistent instance for prototyping,
+  # set database_path to a local directory
+  database_path: ""
+
+  # Set the name of the collection to use as `index_name`
+  index_name: nlweb_collection
+  db_type: qdrant
+```
 
 ## More Information
 

--- a/code/config/config_retrieval.yaml
+++ b/code/config/config_retrieval.yaml
@@ -20,3 +20,18 @@ endpoints:
     database_path: ../milvus/milvus_prod.db
     index_name: prod_collection
     db_type: milvus
+
+  qdrant:
+    # To connect to a Qdrant server, set the `QDRANT_URL` and optionally `QDRANT_API_KEY`.
+    # > docker run -p 6333:6333 qdrant/qdrant
+    # QDRANT_URL="http://localhost:6333"
+    api_endpoint_env: QDRANT_URL
+    api_key_env: QDRANT_API_KEY
+
+    # To use a local persistent instance for prototyping,
+    # set database_path to a local directory
+    database_path: "/path/to/some/directory"
+
+    # Set the name of the collection to use as `index_name`
+    index_name: nlweb_collection
+    db_type: qdrant

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -9,5 +9,6 @@ google-cloud-aiplatform>=1.38.0
 jsonschema>=4.19.1
 python-dotenv>=1.0.0
 pymilvus>=1.1.0
+qdrant-client>=1.14.0
 aiohttp>=3.9.1
 pyyaml>=6.0.1

--- a/code/retrieval/qdrant_retrieve.py
+++ b/code/retrieval/qdrant_retrieve.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2025 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""
+WARNING: This code is under development and may undergo changes in future releases.
+Backwards compatibility is not guaranteed at this time.
+"""
+
+from typing import Dict
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.http import models
+import json
+import time
+import threading
+from llm.llm import get_embedding
+from config.config import CONFIG
+from utils.logging_config_helper import get_configured_logger
+from utils.logger import LogLevel
+
+logger = get_configured_logger("qdrant_retrieve")
+
+_client_lock = threading.Lock()
+qdrant_clients: Dict[str, AsyncQdrantClient] = {}
+
+
+def _create_client_params(endpoint_config):
+    """Extract client parameters from endpoint config."""
+    params = {}
+
+    url = endpoint_config.api_endpoint
+    path = endpoint_config.database_path
+    api_key = endpoint_config.api_key
+
+    if url:
+        params["url"] = url
+        if api_key:
+            params["api_key"] = api_key
+    elif path:
+        params["path"] = path
+    else:
+        raise ValueError("Either `api_endpoint_env` or `database_path` must be set.")
+
+    return params
+
+
+async def initialize_client(endpoint_name=None):
+    """Initialize Qdrant client."""
+    global qdrant_clients
+    endpoint_name = endpoint_name or CONFIG.preferred_retrieval_endpoint
+
+    with _client_lock:
+        if endpoint_name not in qdrant_clients:
+            logger.info(f"Initializing Qdrant client for endpoint: {endpoint_name}")
+            try:
+                endpoint_config = CONFIG.retrieval_endpoints[endpoint_name]
+
+                params = _create_client_params(endpoint_config)
+
+                qdrant_clients[endpoint_name] = AsyncQdrantClient(**params)
+                logger.info(
+                    f"Successfully initialized Qdrant client for {endpoint_name}"
+                )
+
+                await qdrant_clients[endpoint_name].get_collections()
+                logger.debug("Qdrant connection test successful")
+            except Exception as e:
+                logger.exception(f"Failed to initialize Qdrant client: {str(e)}")
+                raise
+
+
+async def get_qdrant_client(endpoint_name=None):
+    """Get or initialize Qdrant client."""
+    endpoint_name = endpoint_name or CONFIG.preferred_retrieval_endpoint
+    if endpoint_name not in qdrant_clients:
+        await initialize_client(endpoint_name)
+    return qdrant_clients[endpoint_name]
+
+
+def get_collection_name(endpoint_name=None):
+    """Get collection name from endpoint config or use default."""
+    endpoint_name = endpoint_name or CONFIG.preferred_retrieval_endpoint
+    endpoint_config = CONFIG.retrieval_endpoints[endpoint_name]
+    index_name = endpoint_config.index_name
+    return index_name or "nlweb_collection"
+
+
+def create_site_filter(site):
+    """Create a Qdrant filter for site filtering."""
+    if site == "all":
+        return None
+
+    if isinstance(site, list):
+        sites = site
+    elif isinstance(site, str):
+        sites = [site]
+    else:
+        sites = []
+
+    return models.Filter(
+        must=[models.FieldCondition(key="site", match=models.MatchAny(any=sites))]
+    )
+
+
+def format_results(search_result):
+    """Format Qdrant search results to match expected API: [url, text_json, name, site]."""
+    results = []
+    for item in search_result:
+        payload = item.payload
+        url = payload.get("url", "")
+        schema = payload.get("schema_json", "")
+        name = payload.get("name", "")
+        site_name = payload.get("site", "")
+
+        results.append([url, schema, name, site_name])
+
+    return results
+
+
+async def search_db(query, site, num_results=50, endpoint_name=None, query_params=None):
+    """Search Qdrant for records filtered by site and ranked by vector similarity."""
+    endpoint_name = endpoint_name or CONFIG.preferred_retrieval_endpoint
+    logger.info(
+        f"Starting Qdrant search - endpoint: {endpoint_name}, site: {site}, num_results: {num_results}"
+    )
+
+    try:
+        start_embed = time.time()
+        embedding = await get_embedding(query)
+        embed_time = time.time() - start_embed
+
+        start_retrieve = time.time()
+        client = await get_qdrant_client(endpoint_name)
+        collection = get_collection_name(endpoint_name)
+        filter_condition = create_site_filter(site)
+
+        search_result = (
+            await client.query_points(
+                collection_name=collection,
+                query=embedding,
+                limit=num_results,
+                with_payload=True,
+                query_filter=filter_condition,
+            )
+        ).points
+
+        results = format_results(search_result)
+        retrieve_time = time.time() - start_retrieve
+
+        logger.log_with_context(
+            LogLevel.INFO,
+            "Qdrant search completed",
+            {
+                "embedding_time": f"{embed_time:.2f}s",
+                "retrieval_time": f"{retrieve_time:.2f}s",
+                "total_time": f"{embed_time + retrieve_time:.2f}s",
+                "results_count": len(results),
+                "embedding_dim": len(embedding),
+            },
+        )
+
+        return results
+
+    except Exception as e:
+        logger.exception(f"Error in Qdrant search_db: {str(e)}")
+        logger.log_with_context(
+            LogLevel.ERROR,
+            "Qdrant search failed",
+            {
+                "error_type": type(e).__name__,
+                "error_message": str(e),
+                "endpoint": endpoint_name,
+                "site": site,
+            },
+        )
+        raise
+
+
+async def retrieve_item_with_url(url, endpoint_name=None):
+    """Retrieve a specific item by URL from Qdrant database."""
+    endpoint_name = endpoint_name or CONFIG.preferred_retrieval_endpoint
+    logger.info(f"Retrieving item by URL: {url}")
+
+    try:
+        client = await get_qdrant_client(endpoint_name)
+        collection = get_collection_name(endpoint_name)
+
+        filter_condition = models.Filter(
+            must=[models.FieldCondition(key="url", match=models.MatchValue(value=url))]
+        )
+
+        points, _offset = await client.scroll(
+            collection_name=collection,
+            scroll_filter=filter_condition,
+            limit=1,
+            with_payload=True,
+        )
+
+        if not points:
+            logger.warning(f"No item found for URL: {url}")
+            return None
+
+        item = points[0]
+        payload = item.payload
+        formatted_result = [
+            payload.get("url", ""),
+            payload.get("schema_json", ""),
+            payload.get("name", ""),
+            payload.get("site", ""),
+        ]
+
+        logger.info(f"Successfully retrieved item for URL: {url}")
+        return formatted_result
+
+    except Exception as e:
+        logger.exception(f"Error retrieving item with URL: {str(e)}")
+        logger.log_with_context(
+            LogLevel.ERROR,
+            "Qdrant item retrieval failed",
+            {
+                "error_type": type(e).__name__,
+                "error_message": str(e),
+                "url": url,
+                "endpoint": endpoint_name,
+            },
+        )
+        raise

--- a/code/retrieval/retriever.py
+++ b/code/retrieval/retriever.py
@@ -3,7 +3,7 @@
 
 """
 This file contains the base class for all handlers. 
-Currently only supports azure_ai_search and milvus.
+Currently supports azure_ai_search, milvus, and qdrant.
 
 WARNING: This code is under development and may undergo changes in future releases.
 Backwards compatibility is not guaranteed at this time.
@@ -12,6 +12,7 @@ Backwards compatibility is not guaranteed at this time.
 
 import retrieval.milvus_retrieve as milvus_retrieve
 import retrieval.azure_retrieve as azure_retrieve
+import retrieval.qdrant_retrieve as qdrant_retrieve
 import time
 import asyncio
 from config.config import CONFIG
@@ -85,6 +86,9 @@ class DBQueryRetriever:
                         results = await azure_retrieve.search_all_sites(query, num_results, self.endpoint_name, self.query_params)
                     else:
                         results = await azure_retrieve.search_db(query, site, num_results, self.endpoint_name, self.query_params)
+                elif self.db_type == "qdrant":
+                    logger.debug("Routing search to Qdrant retriever")
+                    results = await qdrant_retrieve.search_db(query, site, num_results, self.endpoint_name, self.query_params)
                 else:
                     error_msg = f"Invalid database type: {self.db_type}"
                     logger.error(error_msg)
@@ -158,6 +162,9 @@ class DBItemRetriever:
                 elif self.db_type == "azure_ai_search":
                     logger.debug("Routing to Azure AI Search item retrieval")
                     result = await azure_retrieve.retrieve_item_with_url(url, self.endpoint_name)
+                elif self.db_type == "qdrant":
+                    logger.debug("Routing to Qdrant item retrieval")
+                    result = await qdrant_retrieve.retrieve_item_with_url(url, self.endpoint_name)
                 else:
                     error_msg = f"Invalid database type: {self.db_type}"
                     logger.error(error_msg)

--- a/code/tools/qdrant_load.py
+++ b/code/tools/qdrant_load.py
@@ -1,0 +1,113 @@
+import os
+import sys
+import uuid
+from qdrant_client import QdrantClient
+from qdrant_client.models import Distance, VectorParams, PointStruct
+from db_create_utils import documentsFromCSVLine
+
+# To use a local persistent instance for prototyping,
+# set database_path to a local directory
+QDRANT_PATH = "/path/to/some/directory"
+
+# To connect to a Qdrant server, set the `QDRANT_URL` and optionally `QDRANT_API_KEY`.
+# > docker run -p 6333:6333 qdrant/qdrant
+QDRANT_URL = None
+QDRANT_API_KEY = None
+
+COLLECTION_NAME = "nlweb_collection"
+EMBEDDING_SIZE = 1536
+
+EMBEDDINGS_PATH_SMALL = "/Users/anush/Desktop/NLWeb/data/sites/embeddings/small"
+
+# Initialize Qdrant client
+client = QdrantClient(url=QDRANT_URL, api_key=QDRANT_API_KEY, path=QDRANT_PATH)
+
+
+def recreate_collection(collection_name, vector_size):
+    """Recreate a collection in Qdrant"""
+    if client.collection_exists(collection_name):
+        print(f"Dropping existing collection '{collection_name}'")
+        client.delete_collection(collection_name)
+
+    print(f"Creating collection '{collection_name}' with vector size {vector_size}")
+    client.create_collection(
+        collection_name=collection_name,
+        vectors_config=VectorParams(size=vector_size, distance=Distance.COSINE),
+    )
+
+
+def get_documents_from_csv(csv_file_path, site):
+    """Reads and parses documents from a CSV-style text file"""
+    documents = []
+    with open(csv_file_path, "r", encoding="utf-8") as file:
+        for line in file:
+            if line.strip():
+                try:
+                    docs = documentsFromCSVLine(line, site)
+                    documents.extend(docs)
+                except ValueError as e:
+                    print(f"Skipping row due to error: {str(e)}")
+    return documents
+
+
+def get_uuid_from_id(text_id):
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, text_id))
+
+
+def upload_documents_to_qdrant(documents, collection_name):
+    """Upload documents to Qdrant"""
+    points = []
+    for doc in documents:
+        if "embedding" not in doc or not doc["embedding"]:
+            continue
+        point_id = get_uuid_from_id(doc["id"])
+        vector = doc["embedding"]
+        payload = {
+            "url": doc.get("url"),
+            "name": doc.get("name"),
+            "site": doc.get("site"),
+            "schema_json": doc.get("schema_json"),
+        }
+        points.append(PointStruct(id=point_id, vector=vector, payload=payload))
+
+    if points:
+        client.upsert(collection_name=collection_name, points=points)
+        print(f"Uploaded {len(points)} points to Qdrant collection '{collection_name}'")
+
+
+def upload_data_from_csv(csv_file_path, site, collection_name):
+    documents = get_documents_from_csv(csv_file_path, site)
+    print(f"Found {len(documents)} documents in {site}")
+    upload_documents_to_qdrant(documents, collection_name)
+    return len(documents)
+
+
+def main():
+    complete_reload = len(sys.argv) <= 1 or sys.argv[1].lower() == "reload=true"
+
+    if complete_reload:
+        recreate_collection(COLLECTION_NAME, EMBEDDING_SIZE)
+
+    embedding_paths = [EMBEDDINGS_PATH_SMALL]
+    total_documents = 0
+
+    for path in embedding_paths:
+        csv_files = [
+            f.replace(".txt", "") for f in os.listdir(path) if f.endswith(".txt")
+        ]
+        for csv_file in csv_files:
+            print(f"\nProcessing file: {csv_file}")
+            csv_file_path = os.path.join(path, f"{csv_file}.txt")
+            try:
+                documents_added = upload_data_from_csv(
+                    csv_file_path, csv_file, COLLECTION_NAME
+                )
+                total_documents += documents_added
+            except Exception as e:
+                print(f"Error processing file {csv_file}: {e}")
+
+    print(f"\nData processing completed. Total documents added: {total_documents}")
+
+
+if __name__ == "__main__":
+    main()

--- a/static/dropdown-interface.js
+++ b/static/dropdown-interface.js
@@ -241,7 +241,8 @@ export class DropdownInterface {
     return [
       { id: 'azure_ai_search_1', name: 'NLWeb_Crawl' },
       { id: 'azure_ai_search_2', name: 'Bing_Crawl' },
-      { id: 'milvus_1', name: 'Milvus' }
+      { id: 'milvus_1', name: 'Milvus' },
+      { id: 'qdrant', name: 'Qdrant' },
     ];
   }
 }


### PR DESCRIPTION
## Descripton

This PR adds support for a [Qdrant](https://qdrant.tech/) based retriever. I've unit tested the search methods.

# Local mode

The Python client can emulate APIs of the Qdrant server(Rust) without having to run one. It's for prototyping and CIs.

Set `database_path` to a local directory.

```yaml
 qdrant:
    database_path: "path/to/local/directory"
```

Use `code/tools/qdrant_load.py` to add the data after setting

```py
QDRANT_PATH = "path/to/local/directory"
```

# Using Qdrant server

To run Qdrant:

```bash
docker run -p 6333:6333 qdrant/qdrant
```

```yaml
qdrant:
   api_endpoint_env: QDRANT_URL
```

> .env

`QDRANT_URL="http://localhost:6333"`

Use `code/tools/qdrant_load.py` to add the data after setting

```py
QDRANT_URL="http://localhost:6333"
```

You can add data by referring to the documentation [here](https://qdrant.tech/documentation/concepts/points/#:~:text=or%20record%2Doriented%20equivalent:) after [creating a collection](https://qdrant.tech/documentation/concepts/collections/#create-a-collection).

There'll be a dashboard available at http://localhost:6333/dashboard.