### PR TITLE
[Snowflake]: Fix Snowflake providers after recent refactorings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install -r requirements.txt
 
    If you want to use the Azure OpenAI service, follow the instructions below at [Azure OpenAI endpoint creation instructions](#azure-openai-endpoint-creation).  If you are participating in the private preview, the Azure AI Search API keys will be provided for you in a separate document.
 
-   If you want to use Snowflake services, follow the instructions at [docs/Snowflake.md](docs\Snowflake.md).
+   If you want to use Snowflake services, follow the instructions at [docs/Snowflake.md](docs/Snowflake.md).
 
    Then, copy the `.env.template` file into a new file named `.env` and add your keys for this resource into the .env file.
 

--- a/code/config/config_embedding.yaml
+++ b/code/config/config_embedding.yaml
@@ -21,7 +21,7 @@ providers:
     model: text-embedding-3-small
 
   snowflake:
-    api_key_env: SNOWFLAKE_API_KEY
-    api_endpoint_env: SNOWFLAKE_ENDPOINT
+    api_key_env: SNOWFLAKE_PAT
+    api_endpoint_env: SNOWFLAKE_ACCOUNT_URL
     api_version_env: "2024-10-01"
-    model: snowflake-embedding-v1
+    model: snowflake-arctic-embed-m-v1.5

--- a/code/config/config_llm.yaml
+++ b/code/config/config_llm.yaml
@@ -46,9 +46,9 @@ providers:
 
       
   snowflake:
-    api_key_env: SNOWFLAKE_API_KEY
-    api_endpoint_env: SNOWFLAKE_ENDPOINT
+    api_key_env: SNOWFLAKE_PAT
+    api_endpoint_env: SNOWFLAKE_ACCOUNT_URL
     api_version_env: "2024-12-01"
     models:
-      high: arctic-1.0
-      low: arctic-0.5
+      high: claude-3-5-sonnet
+      low: llama3.1-8b

--- a/code/config/config_retrieval.yaml
+++ b/code/config/config_retrieval.yaml
@@ -48,6 +48,7 @@ endpoints:
     db_type: qdrant
 
   snowflake_cortex_search_1:
+    api_key_env: SNOWFLAKE_PAT
     api_endpoint_env: SNOWFLAKE_ACCOUNT_URL
     index_name: SNOWFLAKE_CORTEX_SEARCH_SERVICE
     db_type: snowflake_cortex_search

--- a/code/embedding/embedding.py
+++ b/code/embedding/embedding.py
@@ -119,12 +119,12 @@ async def get_embedding(
         if provider == "snowflake":
             logger.debug("Getting Snowflake embeddings")
             # Import here to avoid potential circular imports
-            from embedding.snowflake_embedding import get_snowflake_embeddings
+            from embedding.snowflake_embedding import cortex_embed
             result = await asyncio.wait_for(
-                get_snowflake_embeddings(text, model=model_id),
+                cortex_embed(text, model=model_id),
                 timeout=timeout
             )
-            logger.debug(f"Snowflake embeddings received, dimension: {len(result)}")
+            logger.debug(f"Snowflake Cortex embeddings received, dimension: {len(result)}")
             return result
 
         error_msg = f"No embedding implementation for provider '{provider}'"

--- a/code/embedding/snowflake_embedding.py
+++ b/code/embedding/snowflake_embedding.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2025 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""
+Adapting the Snowflake Cortex Embedding REST APIs to interfaces e
+
+Currently uses raw REST requests to act as the simplest, lowest-level reference.
+An alternative would have been to use the Snowflake Python SDK as outlined in:
+https://docs.snowflake.com/en/developer-guide/snowpark-ml/reference/1.8.1/index-cortex
+
+
+WARNING: This code is under development and may undergo changes in future releases.
+Backwards compatibility is not guaranteed at this time.
+"""
+
+import logging
+import httpx
+from typing import List
+
+from config.config import CONFIG
+from utils import snowflake
+
+logger = logging.getLogger(__name__)
+
+
+async def cortex_embed(text: str, model: str|None = None) -> List[float]:
+    """
+    Embed text using snowflake.cortex.embed.
+
+    See: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-llm-rest-api#label-cortex-llm-embed-function
+    """
+    cfg = CONFIG.get_embedding_provider("snowflake")
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            snowflake.get_account_url(cfg) + "/api/v2/cortex/inference:embed",
+            json={
+                "text": [text], 
+                "model": model or "snowflake-arctic-embed-m-v1.5"
+            },
+            headers={
+                    "Authorization": f"Bearer {snowflake.get_pat(cfg)}",
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+            },
+        )
+        if response.status_code == 400:
+            raise Exception(response.json())
+        response.raise_for_status()
+        return response.json().get("data")[0].get("embedding")[0]

--- a/code/llm/snowflake.py
+++ b/code/llm/snowflake.py
@@ -2,11 +2,7 @@
 # Licensed under the MIT License
 
 """
-Snowflake AI wrapper for LLM functionality.
-
-Snowflake Cortex wrapper.
-
-Wrappers over the Snowflake Cortex REST APIs.
+Adapting the Snowflake Cortex LLM REST APIs to the LLMProvider interface.
 
 Currently uses raw REST requests to act as the simplest, lowest-level reference.
 An alternative would have been to use the Snowflake Python SDK as outlined in:
@@ -17,62 +13,26 @@ WARNING: This code is under development and may undergo changes in future releas
 Backwards compatibility is not guaranteed at this time.
 """
 
-
-import os
 import json
 import re
 import logging
-import asyncio
+import httpx
 from typing import Dict, Any, List, Optional
 
 from config.config import CONFIG
-import threading
-
 from llm.llm_provider import LLMProvider
+from utils import snowflake
 
 logger = logging.getLogger(__name__)
 
 
-class ConfigurationError(RuntimeError):
-    """Raised when configuration is missing or invalid."""
-    pass
-
-
 class SnowflakeProvider(LLMProvider):
-    """Implementation of LLMProvider for Snowflake AI."""
-    
-    _client_lock = threading.Lock()
-    _client = None
-
-    @classmethod
-    def get_api_key(cls) -> str:
-        """Retrieve the Snowflake API key from the environment or raise an error."""
-        # Get the API key from the preferred provider config
-        provider_config = CONFIG.llm_providers.get("snowflake")
-        if not provider_config:
-            raise ConfigurationError("Snowflake provider not configured")
-            
-        api_key_env_var = provider_config.api_key_env
-        
-        key = os.getenv(api_key_env_var)
-        if not key:
-            raise ConfigurationError(f"{api_key_env_var} is not set")
-        return key
+    """Implementation of LLMProvider for Snowflake LLM REST API calls."""
 
     @classmethod
     def get_client(cls):
-        """
-        Configure and return a Snowflake client.
-        
-        Note: This is a placeholder implementation as the actual client
-        initialization would depend on the Snowflake AI SDK.
-        """
-        with cls._client_lock:  # Thread-safe client initialization
-            if cls._client is None:
-                # TODO: Initialize Snowflake client
-                # This is a stub implementation
-                cls._client = None
-        return cls._client
+        """No-op since no persistent client is needed."""
+        return None
 
     @classmethod
     def clean_response(cls, content: str) -> Dict[str, Any]:
@@ -97,51 +57,32 @@ class SnowflakeProvider(LLMProvider):
         **kwargs
     ) -> Dict[str, Any]:
         """
-        Send an async chat completion request to Snowflake AI and return parsed JSON.
-        
-        Note: This is a placeholder implementation as the actual API calls
-        would depend on the Snowflake AI SDK.
+        Send an async chat completion request via snowflake.cortex.complete and return parsed JSON output.
+
+        See: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-llm-rest-api#complete-function
+
+        Arguments:
+        - prompt: The prompt to complete
+        - schema: JSON schema of the desired response.
+        - model: The name of the model to use (if not specified, one will be chosen)
+        - max_tokens: A value between 1 and 4096 (inclusive) that controls the maximum number of tokens to output. Output is truncated after this number of tokens.
+        - top_p: A value from 0 to 1 (inclusive) that controls the diversity of the language model by restricting the set of possible tokens that the model outputs.
+        - temperature: A value from 0 to 1 (inclusive) that controls the randomness of the output of the language model by influencing which possible token is chosen at each step.
         """
-        # If model not provided, get it from config
-        if model is None:
-            provider_config = CONFIG.llm_providers.get("snowflake")
-            if provider_config and provider_config.models:
-                # Use the 'high' model for completions by default
-                model = provider_config.models.high
-        
-        # TODO: Implement actual Snowflake AI API call
-        # This is a stub implementation that raises NotImplementedError
-        raise NotImplementedError("Snowflake AI provider is not yet implemented")
+        return await cortex_complete(prompt, schema, model, max_tokens, temperature, timeout)
 
 
 # Create a singleton instance
 provider = SnowflakeProvider()
 
 
-async def cortex_embed(text: str, model: str|None = None) -> List[float]:
-    """
-    Embed text using snowflake.cortex.embed.
-
-    See: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-llm-rest-api#label-cortex-llm-embed-function
-    """
-    if model is None:
-        model = get_embedding_model()
-    response = await post(
-        "/api/v2/cortex/inference:embed",
-        {
-            "text":[text], 
-            "model":model,
-        })
-    return response.get("data")[0].get("embedding")[0]
-        
-
 async def cortex_complete(
-        prompt: str, 
+        prompt: str,
         schema: Dict[str, Any],
         model: str|None = None, 
         max_tokens: int = 4096, 
-        top_p: float=1.0, 
-        temperature: float=0.0) -> str:
+        temperature: float=0.0,
+        timeout: float=60.0) -> str:
     """
     Send an async chat completion request via snowflake.cortex.complete and return parsed JSON output.
 
@@ -152,8 +93,8 @@ async def cortex_complete(
     - schema: JSON schema of the desired response.
     - model: The name of the model to use (if not specified, one will be chosen)
     - max_tokens: A value between 1 and 4096 (inclusive) that controls the maximum number of tokens to output. Output is truncated after this number of tokens.
-    - top_p: A value from 0 to 1 (inclusive) that controls the diversity of the language model by restricting the set of possible tokens that the model outputs.
     - temperature: A value from 0 to 1 (inclusive) that controls the randomness of the output of the language model by influencing which possible token is chosen at each step.
+    - timeout: Maximum time (in seconds) to wait for a response.
     """
     if model is None:
         model = "claude-3-5-sonnet"
@@ -162,7 +103,6 @@ async def cortex_complete(
         {
             "model": model,
             "max_tokens": max_tokens,
-            "top_p": top_p,
             "temperature": temperature,
             "messages": [
                 # The precise system prompt may need adjustment given a model. For example, a simpler prompt worked well for larger
@@ -173,28 +113,23 @@ async def cortex_complete(
                 {"role": "user", "content": prompt},
             ],
             "stream": False,
-        }
+        },
+        timeout,
     )
-    content = response.get("choices")[0].get("message").get("content").strip()
-    # Attempt to be resilient to the model adding something before or after the JSON
-    start_idx = content.find('{')
-    limit_idx = content.rfind('}')+1
-    if start_idx < 0 or limit_idx <= 0:
-        raise ValueError(f"model did not generate valid JSON, it generated '{content}'")
-    return json.loads(content[start_idx:limit_idx])
-    
+    return SnowflakeProvider.clean_response(response.get("choices")[0].get("message").get("content").strip())
 
-async def post(api: str, request: dict) -> dict:
+async def post(api: str, request: dict, timeout: float) -> dict:
+    cfg = CONFIG.llm_providers.get("snowflake")
     async with httpx.AsyncClient() as client:
         response =  await client.post(
-            snowflake.get_account_url() + api,
+            snowflake.get_account_url(cfg) + api,
             json=request,
             headers={
-                    "Authorization": f"Bearer {snowflake.get_pat()}",
+                    "Authorization": f"Bearer {snowflake.get_pat(cfg)}",
                     "Content-Type": "application/json",
                     "Accept": "application/json",
             },
-            timeout=60,
+            timeout=timeout,
         )
         if response.status_code == 400:
             raise Exception(response.json())

--- a/code/retrieval/retriever.py
+++ b/code/retrieval/retriever.py
@@ -20,6 +20,7 @@ from utils.logger import LogLevel
 from retrieval.azure_search_client import AzureSearchClient
 from retrieval.milvus_client import MilvusVectorClient
 from retrieval.qdrant_client import QdrantVectorClient
+from retrieval.snowflake_client import SnowflakeCortexSearchClient
 
 logger = get_configured_logger("retriever")
 
@@ -171,6 +172,8 @@ class VectorDBClient:
                 client = MilvusVectorClient(self.endpoint_name)
             elif self.db_type == "qdrant":
                 client = QdrantVectorClient(self.endpoint_name)
+            elif self.db_type == "snowflake_cortex_search":
+                client = SnowflakeCortexSearchClient(self.endpoint_name)
             else:
                 error_msg = f"Unsupported database type: {self.db_type}"
                 logger.error(error_msg)

--- a/code/utils/snowflake.py
+++ b/code/utils/snowflake.py
@@ -1,28 +1,29 @@
 """Functions for extracting Snowflake connection parameters from configuration."""
 
-from config.config import CONFIG
+from config.config import CONFIG, LLMProviderConfig, EmbeddingProviderConfig, RetrievalProviderConfig
 
 class ConfigurationError(RuntimeError):
     """Raised when configuration is missing or invalid"""
     pass
 
-def get_pat() -> str:
+def get_pat(cfg: LLMProviderConfig|EmbeddingProviderConfig|RetrievalProviderConfig) -> str:
     """
     Retrieve the Programmatic Access Token (PAT) from the environment, or raise an error.
     """
-    config = CONFIG.providers.get("snowflake")
-    pat = config.api_key.strip('"') if config and config.api_key else None
+    pat = cfg.api_key.strip('"') if cfg and cfg.api_key else None
     if not pat:
         raise ConfigurationError(f"Unable to determine Snowflake Programmatic Access Token to use (PAT), is SNOWFLAKE_PAT set?")
     return pat
 
 
-def get_account_url() -> str:
+def get_account_url(cfg: LLMProviderConfig|EmbeddingProviderConfig|RetrievalProviderConfig) -> str:
     """
     Retrieve the account URL that is the base URL for all Snowflake Cortex API REST calls, or raise an error.
     """
-    config = CONFIG.providers.get("snowflake")
-    account_url = config.endpoint.strip('"')
+    # Unfortunately, LLMProviderCondfig and EmbeddingProviderConfig use 'endpoint'
+    # while RetrievalProviderConfig uses 'api_endpoint', so handle both.
+    endpoint = cfg.api_endpoint if isinstance(cfg, RetrievalProviderConfig) else cfg.endpoint
+    account_url = endpoint.strip('"')
     if not account_url:
         raise ConfigurationError(f"Unable to determine Snowflake Account URL, is SNOWFLAKE_ACCOUNT_URL set?")
     return account_url

--- a/static/dropdown-interface.js
+++ b/static/dropdown-interface.js
@@ -216,8 +216,7 @@ export class DropdownInterface {
    */
   getSites() {
     return [
-
-      'imdb', 'nytimes', 'verge','delish','alltrails', 'allbirds', 'seriouseats', 'oreilly',
+      'scifi_movies','imdb', 'nytimes', 'verge','delish','alltrails', 'allbirds', 'seriouseats', 'oreilly',
       'npr podcasts', 'backcountry', 'bc_product', 'neurips', 'zillow', 'eventbrite',
       'tripadvisor', 'woksoflife', 'cheftariq', 'hebbarskitchen',
       'latam_recipes', 'spruce', 'med podcast', 'allbirdsdd', 'all'


### PR DESCRIPTION
- Add a Snowflake Embedding provider
- Make the LLM/Embedding/Retrieval providers conform to the new interface
- Make snowflake-connectivity.py use the generic interfaces, not snowflake specific ones.
- Make sfici_movies the first dataset in the sample app.

TESTED:
- `python snowflake-connectivity.py`
- Changed default providers to snowflake in the configs, then ran `python app-file.py` and tried the scifi_movies searches, got results.