### PR TITLE
Changing endpoint name back as there are hardcoded references to it…

### DIFF
--- a/code/config/config_retrieval.yaml
+++ b/code/config/config_retrieval.yaml
@@ -1,7 +1,7 @@
-preferred_endpoint: azure_ai_search
+preferred_endpoint: azure_ai_search_1
 
 endpoints:
-  azure_ai_search:
+  azure_ai_search_1:
     api_key_env: AZURE_VECTOR_SEARCH_API_KEY
     api_endpoint_env: AZURE_VECTOR_SEARCH_ENDPOINT
     index_name: embeddings1536


### PR DESCRIPTION
Changing endpoint name back as there are hardcoded references to it in sample code.  We can do a refactoring later to get rid of all of the _1 for consistency if needed