### PR TITLE
Updated minimum Python version to 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Use these instructions to run an NLWeb server - below we have instructions for:
 
 ## Prerequisites
 
-These instructions assume that you have an [Azure subscription](https://go.microsoft.com/fwlink/?linkid=2227353&clcid=0x409&l=en-us&icid=nlweb), the [Azure CLI installed locally](https://learn.microsoft.com/cli/azure/install-azure-cli), and have Python 3.9+ installed locally.
+These instructions assume that you have an [Azure subscription](https://go.microsoft.com/fwlink/?linkid=2227353&clcid=0x409&l=en-us&icid=nlweb), the [Azure CLI installed locally](https://learn.microsoft.com/cli/azure/install-azure-cli), and have Python 3.10+ installed locally.
 
 
 ## Local Setup


### PR DESCRIPTION
This was based on a reported partner issue working with Snowflake components, and I would like to use [Python's match](https://www.geeksforgeeks.org/python-match-case-statement/) in the check_connectivity script which requires Python 3.10 as well.  