### PR TITLE
Fix empty documents being loaded in vector db load

### DIFF
--- a/code/tools/trim_schema_json.py
+++ b/code/tools/trim_schema_json.py
@@ -60,7 +60,7 @@ def trim_schema_json_list(schema_json, site):
         trimmed_item = trim_schema_json(item, site)
         if trimmed_item is not None:
             trimmed_items.append(trimmed_item)
-    return trimmed_items
+    return trimmed_items or None
 
 def trim_schema_json(schema_json, site):
     if isinstance(schema_json, list):


### PR DESCRIPTION
The following JSON-LD snippet results in a empty document being created when the schema is passed to trim_schema_json. This JSON contains two objects which are both skipped by the exclude rules. trim_schema_json_list then returns an empty list instead of None. This empty list gets appended to the list of documents and you end up with an empty document for each URL uploaded to during db load. (db_load_utils.documents_from_csv_line creates documents for every item returned from trim_schema_json).  

```
[
    {
      "@context": "http://schema.org",
      "@type": "Organization",
      "name": "Tripadvisor",
      "url": "https://www.tripadvisor.com/",
      "logo": "https://static.tacdn.com/img2/brand_refresh/Tripadvisor_logoset_solid_green.svg",
      "sameAs": [
        "https://www.facebook.com/Tripadvisor",
        "https://twitter.com/Tripadvisor",
        "https://instagram.com/tripadvisor/",
        "https://www.linkedin.com/company/tripadvisor"
      ]
    },
    {
      "@context": "http://schema.org",
      "@type": "WebSite",
      "name": "Tripadvisor",
      "url": "https://www.tripadvisor.com/",
      "potentialAction": {
        "@type": "SearchAction",
        "target": {
          "@type": "EntryPoint",
          "urlTemplate": "https://www.tripadvisor.com/Search?q={search_term_string}"
        },
        "query-input": "required name=search_term_string"
      }
    }
  ]
```

This is the entire JSON-LD being parsed: [full.json](https://github.com/user-attachments/files/20235586/full.json)