### PR TITLE
allow nlweb script to invoke data load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.userosscache
 *.sln.docstates
 myenv
+venv
 .env
 
 

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -12,7 +12,7 @@ To set up the `nlweb` command-line interface, you need to source the setup scrip
 source setup.sh
 ```
 
-This will temporarily add the `nlweb` command to your PATH and create an alias for easier use. 
+This will temporarily add the `nlweb` command to your PATH and create an alias for easier use.
 
 ### The NL Web CLI offers several advantages:
 
@@ -33,9 +33,11 @@ The `nlweb` CLI provides the following commands:
 | Command | Description |
 |---------|-------------|
 | `init`  | Configure the LLM provider and retrieval endpoint |
+| `init-python` | Set up Python virtual environment and install dependencies |
 | `check` | Verify connectivity for selected configuration and environment variables |
 | `app`   | Run the web application |
 | `run`   | End-to-end flow: Runs `init`, `check`, and `app` sequentially |
+| `data-load` | Load data from an RSS feed URL with a specified site name |
 
 ### Common Flags
 
@@ -141,6 +143,46 @@ nlweb run -d
 ```
 
 This provides detailed logging information that can help identify configuration problems.
+
+### Python Virtual Environment Setup
+
+To set up the Python virtual environment:
+
+```bash
+nlweb init-python
+```
+
+This will:
+1. Create a Python virtual environment in the `venv` directory
+2. Install all required dependencies from `requirements.txt`
+
+**Note**: When running `init-python` from the CLI, the virtual environment will be activated only within the script's execution context. After the command completes, your shell won't remain in the activated virtual environment.
+
+To activate the virtual environment in your current shell session, you need to source the activation script:
+
+```bash
+source venv/bin/activate
+```
+
+Alternatively, if you need to set up and use the environment in one step, you can use:
+
+```bash
+nlweb init-python && source venv/bin/activate
+```
+
+This will both set up the Python environment and activate it in your current shell session.
+
+### Data Loading
+
+To load data from an RSS feed:
+
+```bash
+nlweb data-load
+```
+
+This command will prompt you for:
+- An RSS URL to load data from
+- A site name for the loaded data
 
 ## Conclusion
 

--- a/scripts/cli/nlweb.sh
+++ b/scripts/cli/nlweb.sh
@@ -17,11 +17,34 @@ declare me=$(basename "$0")
 function init(){
   configure_llm_provider
   configure_retrieval_endpoint
+  }
+
+function dataload(){
+  local rss_url
+  _prompt_input "Please enter an RSS url" rss_url
+
+  local site_name
+  _prompt_input "Please enter a site name" site_name
+
+  _debug "Loading data from $rss_url site name: $site_name"
+  python -m tools.db_load "$rss_url" "$site_name"
+}
+
+function init_python(){
+  python -m venv venv
+  source venv/bin/activate
+
+  pushd "$REPO_DIR/code" > /dev/null || exit 1
+    pip install -r requirements.txt
+  popd || exit 1
+
+  _info "Run 'source venv/bin/activate' to activate the virtual environment"
 }
 
 function run(){
   init
   check
+  dataload
   app
 }
 
@@ -41,6 +64,10 @@ function app(){
 function parse_args() {
   while (("$#")); do
     case "${1}" in
+    data-load)
+        shift 1
+        export command="dataload"
+        ;;       
     check)
         shift 1
         export command="check"
@@ -57,6 +84,10 @@ function parse_args() {
         shift 1
         export command="init"
         ;;
+    init-python)
+        shift 1
+        export command="initpython"
+        ;;        
     -h | --help)
         shift 1
         export command="help"
@@ -89,6 +120,12 @@ process_command() {
     ;;    
   check)
     check
+    ;;
+  dataload)
+    dataload
+    ;;
+  initpython)
+    init_python
     ;;
   view)
     view


### PR DESCRIPTION
This PR introduces a change to the `nlweb` cli script including:

- a `nlweb data-load` command to prompt the user for an rss url and site name, it then invokes the data load script.
- a `nlweb init-python` command to set up the virtual environment and perform a pip install. This is a convenience command and not required.