### PR TITLE
aiohttp increase max line and max field size of client session 

### DIFF
--- a/code/tools/db_load.py
+++ b/code/tools/db_load.py
@@ -32,6 +32,10 @@ from retrieval.retriever import get_vector_db_client
 # Import RSS to Schema converter
 import tools.rss2schema as rss2schema
 
+# Injected constants for aiohttp session limits
+AIOHTTP_CLIENTSESSION_MAX_LINE_SIZE = 32_768      # 32 KB per header line
+AIOHTTP_CLIENTSESSION_MAX_FIELD_SIZE = 32_768     # 32 KB per header field
+
 # Define URL extractor function since json_url_extractor module is not available
 def process_line(line):
     """
@@ -168,7 +172,10 @@ async def fetch_url(url: str) -> Tuple[str, Optional[str]]:
     print(f"Fetching content from URL: {url}")
     
     try:
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(
+            max_line_size=AIOHTTP_CLIENTSESSION_MAX_LINE_SIZE,
+            max_field_size=AIOHTTP_CLIENTSESSION_MAX_FIELD_SIZE
+        ) as session:
             async with session.get(url) as response:
                 if response.status != 200:
                     raise ValueError(f"Failed to fetch URL {url}: HTTP {response.status}")


### PR DESCRIPTION
aiohttp uses the default values for max_line_size and max_field_size for ClientSession and the db_load fails if it goes above this value. 

https://docs.aiohttp.org/en/stable/client_reference.html

max_line_size: Maximum allowed size of lines in responses.
max_field_size: Maximum allowed size of header fields in responses.

And example of this failing is this load of the RSS feed:

`python -m tools.db_load https://www.bhf.org.uk/rss/news RSS
`

This PR both increases the size to 32KB for both header and field sizes and allows it to be injectable when the `ClientSession ` is initalised.  