### PR TITLE
fix: Duplicate message sent for answer synthesis

### DIFF
--- a/code/core/generate_answer.py
+++ b/code/core/generate_answer.py
@@ -179,12 +179,10 @@ class GenerateAnswer(NLWebHandler):
             json_results = []
             description_tasks = []
             answer = response["answer"]
-            
+
             # Create initial message with just the answer
             message = {"message_type": "nlws", "answer": answer, "items": json_results}
-            logger.info("Sending initial answer")
-            await self.send_message(message)
-            
+
             # Process each URL mentioned in the response
             if "urls" in response and response["urls"]:
                 for url in response["urls"]:
@@ -218,14 +216,14 @@ class GenerateAnswer(NLWebHandler):
                             "site": site,
                             "schema_object": json.loads(json_str),
                         })
-                        
+
                     # Update message with descriptions
                     message = {"message_type": "nlws", "answer": answer, "items": json_results}
-                    logger.info(f"Sending final answer with {len(json_results)} item descriptions")
-                    await self.send_message(message)
             else:
                 logger.warning("No URLs found in synthesis response")
-                
+
+            logger.info(f"Sending final answer with {len(json_results)} item descriptions")
+            await self.send_message(message)
         except Exception as e:
             logger.exception(f"Error in synthesizeAnswer: {e}")
             if self.connection_alive_event.is_set():

--- a/refactored/code/methods/generate_answer.py
+++ b/refactored/code/methods/generate_answer.py
@@ -179,12 +179,10 @@ class GenerateAnswer(NLWebHandler):
             json_results = []
             description_tasks = []
             answer = response["answer"]
-            
+
             # Create initial message with just the answer
             message = {"message_type": "nlws", "answer": answer, "items": json_results}
-            logger.info("Sending initial answer")
-            await self.send_message(message)
-            
+
             # Process each URL mentioned in the response
             if "urls" in response and response["urls"]:
                 for url in response["urls"]:
@@ -218,14 +216,14 @@ class GenerateAnswer(NLWebHandler):
                             "site": site,
                             "schema_object": json.loads(json_str),
                         })
-                        
+
                     # Update message with descriptions
                     message = {"message_type": "nlws", "answer": answer, "items": json_results}
-                    logger.info(f"Sending final answer with {len(json_results)} item descriptions")
-                    await self.send_message(message)
             else:
                 logger.warning("No URLs found in synthesis response")
-                
+
+            logger.info(f"Sending final answer with {len(json_results)} item descriptions")
+            await self.send_message(message)
         except Exception as e:
             logger.exception(f"Error in synthesizeAnswer: {e}")
             if self.connection_alive_event.is_set():


### PR DESCRIPTION
This PR fixes an issue where duplicate answer that has no item is sent during answer synthesis.

## Before

![before-1](https://github.com/user-attachments/assets/4538500a-8d09-44a4-99b4-d84cace82c55)

![before-2](https://github.com/user-attachments/assets/3de2eca9-bbc1-40d7-9ac7-46cd4a52e876)

## After

![after](https://github.com/user-attachments/assets/a7406799-0f85-42c5-a675-728abab9c2d8)
