### PR TITLE
Fix: Handle list parameters in get_param function

### DIFF
--- a/code/python/core/utils/utils.py
+++ b/code/python/core/utils/utils.py
@@ -52,6 +52,8 @@ def get_param(query_params, param_name, param_type=str, default_value=None):
     value = query_params.get(param_name, default_value)
     if (value is not None):
         if param_type == str:\
+            if isinstance(value, list):
+                return value[0] if value else ""
             return value    
         elif param_type == int:\
             return int(value)


### PR DESCRIPTION
# Fix: Handle list parameters in get_param function

## Problem
The `get_param` function in `utils.py` throws type errors when query parameters are received as lists instead of strings. This is a critical issue that prevents results from being displayed.

## Changes Made
This PR adds proper handling for list-type parameters in the `get_param` function:

### core/utils/utils.py
- Added type checking to detect when a parameter value is a list
- When a list is encountered and a string is expected, returns the first element of the list
- Returns empty string if the list is empty to maintain consistent return type