### PR TITLE
Fix state management naming for ToolSelector step completion

### DIFF
--- a/code/python/core/state.py
+++ b/code/python/core/state.py
@@ -22,7 +22,7 @@ class NLWebHandlerState:
             self.precheck_step_state[step_name] = self.__class__.DONE
             if step_name == "Decon":
                 self._decon_event.set()
-            elif step_name == "ToolRouter":
+            elif step_name == "ToolSelector":
                 self._tool_router_event.set()
             # Check if all steps are done
             if all(state == self.__class__.DONE for state in self.precheck_step_state.values()):
@@ -58,8 +58,8 @@ class NLWebHandlerState:
         return self.is_tool_routing_done()
     
     def is_tool_routing_done(self):
-        if "ToolRouter" in self.precheck_step_state:
-            return self.precheck_step_state["ToolRouter"] == self.__class__.DONE
+        if "ToolSelector" in self.precheck_step_state:
+            return self.precheck_step_state["ToolSelector"] == self.__class__.DONE
         else:
             return False
     


### PR DESCRIPTION
Renamed from `ToolRouter` to `ToolSelector`.

There is a naming mismatch with the tool selector class from `router.py` which prevents `wait_for_tool_routing()` from working. https://github.com/microsoft/NLWeb/blob/main/code/python/core/router.py#L134

Does not impact production code, but creates potential bugs if future code tries to use tool routing coordination.