### PR TITLE
Correct tool reference in MCP test

### DIFF
--- a/static/mcp_test.html
+++ b/static/mcp_test.html
@@ -757,7 +757,7 @@
                 id: 2,
                 method: "tools/call",
                 params: {
-                    name: "ask_nlweb",
+                    name: "ask",
                     arguments: args
                 }
             };
@@ -862,7 +862,7 @@
                 id: 2,
                 method: "tools/call",
                 params: {
-                    name: "ask_nlweb",
+                    name: "ask",
                     arguments: args
                 }
             };


### PR DESCRIPTION
When running the MCP Test (http://localhost:8000/static/mcp_test.html) we get the following error:

```
error: {
  code: -32603
  message: "Unknown tool: ask_nlweb"
}
```


This PR fixes it by changing `"ask_nlweb"` to `"ask"` in the `static/mcp_test.html` file.