### PR TITLE
Set Shopify MCP Retriever Default to False

### DIFF
--- a/config/config_retrieval.yaml
+++ b/config/config_retrieval.yaml
@@ -47,7 +47,7 @@ endpoints:
 
   # Shopify MCP endpoint for product search across Shopify stores
   shopify:
-    enabled: true
+    enabled: false
     db_type: shopify_mcp
     # Note: mcp_endpoint will be dynamically set based on the site being queried
     name: Shopify MCP Search


### PR DESCRIPTION
When running `python app-file.py`, accessing `http://localhost:8000/`, and selecting a site we get websites that might not be in our database in the dropdown list:

<img width="943" height="568" alt="image" src="https://github.com/user-attachments/assets/2408767b-3b78-4fe5-a9be-ee3cb4a120ee" />

Cause: the Shopify MCP retriever is set as True by default in the configuration.

This PR updates this default configuration to False.