### PR TITLE
Add Cloudflare AutoRAG as a Retrieval provider

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -70,3 +70,8 @@ NLWEB_LOGGING_PROFILE=production
 
 # Hugging Face Inference Providers env variables
 HF_TOKEN="<TODO>"
+
+# Cloudflare AutoRAG env variables
+CLOUDFLARE_API_TOKEN="<TODO>"
+CLOUDFLARE_RAG_ID_ENV="<TODO>"
+CLOUDFLARE_ACCOUNT_ID="<TODO>"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The response returned uses Schema.org — a widely adopted vocabulary for descri
 NLWeb is platform-agnostic and supports:
 
 * **Operating systems**: Windows, macOS, Linux
-* **Vector stores**: [Qdrant](/docs/setup-qdrant.md), [Snowflake](docs/setup-snowflake.md), [Milvus](/docs/setup-milvus.md), [Azure AI Search](docs/setup-azure.md), [Elasticsearch](docs/setup-elasticsearch.md), [Postgres](docs/setup-postgres.md)
+* **Vector stores**: [Qdrant](/docs/setup-qdrant.md), [Snowflake](docs/setup-snowflake.md), [Milvus](/docs/setup-milvus.md), [Azure AI Search](docs/setup-azure.md), [Elasticsearch](docs/setup-elasticsearch.md), [Postgres](docs/setup-postgres.md), [Cloudflare AutoRAG](docs/setup-cloudflare-autorag.md)
 * **LLMs**: OpenAI, DeepSeek, Gemini, Anthropic, Inception, [HuggingFace](docs/setup-huggingface.md)
 
 It is designed to be lightweight and scalable — capable of running on everything from data center clusters to laptops and, soon, mobile devices.

--- a/code/python/core/retriever.py
+++ b/code/python/core/retriever.py
@@ -65,7 +65,13 @@ def init():
                 elif db_type == "shopify_mcp":
                     from retrieval_providers.shopify_mcp import ShopifyMCPClient
                     _preloaded_modules[db_type] = ShopifyMCPClient
-                
+                elif db_type == "cloudflare_autorag":
+                    from code.python.retrieval_providers.cf_autorag_client import (
+                        CloudflareAutoRAGClient,
+                    )
+
+                    _preloaded_modules[db_type] = CloudflareAutoRAGClient
+
             except Exception as e:
                 logger.warning(f"Failed to preload {db_type} client module: {e}")
 
@@ -79,6 +85,7 @@ _db_type_packages = {
     "elasticsearch": ["elasticsearch[async]>=8,<9"],
     "postgres": ["psycopg", "psycopg[binary]>=3.1.12", "psycopg[pool]>=3.2.0", "pgvector>=0.4.0"],
     "shopify_mcp": ["aiohttp>=3.8.0"],
+    "cloudflare_autorag": ['cloudflare>=4.3.1', "httpx>=0.28.1", "zon>=3.0.0"],
 }
 
 # Cache for installed packages
@@ -433,6 +440,8 @@ class VectorDBClient:
         elif db_type == "shopify_mcp":
             # Shopify MCP doesn't require authentication
             return True
+        elif db_type == "cloudflare_autorag":
+            return bool(config.api_key)
         else:
             logger.warning(f"Unknown database type {db_type} for endpoint {name}")
             return False
@@ -488,6 +497,12 @@ class VectorDBClient:
                 elif db_type == "snowflake_cortex_search":
                     from retrieval_providers.snowflake_client import SnowflakeCortexSearchClient
                     client = SnowflakeCortexSearchClient(endpoint_name)
+                elif db_type == "cloudflare_autorag":
+                    from retrieval_providers.cf_autorag_client import (
+                        CloudflareAutoRAGClient,
+                    )
+
+                    client = CloudflareAutoRAGClient(endpoint_name)
                 elif db_type == "elasticsearch":
                     from retrieval_providers.elasticsearch_client import ElasticsearchClient
                     client = ElasticsearchClient(endpoint_name)

--- a/code/python/requirements.txt
+++ b/code/python/requirements.txt
@@ -72,3 +72,8 @@ openai>=1.12.0
 # psycopg[binary]>=3.1.12  # PostgreSQL adapter (psycopg3)
 # psycopg[pool]>=3.2.0  # Connection pooling for psycopg3
 # pgvector>=0.4.0
+
+# For Cloudflare AutoRAG
+# httpx>=0.28.1
+# cloudflare>=4.3.1
+# zon>=3.0.0

--- a/code/python/retrieval_providers/cf_autorag_client.py
+++ b/code/python/retrieval_providers/cf_autorag_client.py
@@ -1,0 +1,197 @@
+from core.config import CONFIG
+from typing import Any, Dict, List, Optional, Union
+
+import threading
+
+import os
+
+import httpx
+
+from misc.logger.logging_config_helper import get_configured_logger
+from misc.logger.logger import LogLevel
+
+from cloudflare import AsyncCloudflare
+
+import zon as z
+
+logger = get_configured_logger("cloudflare_autorag_client")
+
+searchFiltersComparisonFilter = z.record({
+    "key": z.string(),
+    "type": z.enum(["eq", "ne", "gt", "gte", "lt", "lte"]),
+	"value": z.string().or_else([z.number()]).or_else([z.boolean()]),
+})
+
+searchFiltersCompoundFilter = z.record({
+	"type": z.enum(["and"]), # TODO: add 'or' when vectorize supports it
+	"filters": searchFiltersComparisonFilter.list(),
+})
+
+
+class CloudflareAutoRAGClient:
+    """
+    """
+
+    _cfg = None
+
+    def __init__(self, endpoint_name: Optional[str] = None):
+
+        self.endpoint_name = endpoint_name or CONFIG.write_endpoint
+        logger.info(f"Initialized CloudflareAutoRAGClient for endpoint: {self.endpoint_name}")
+
+        self._client_lock = threading.Lock()
+        self._cf_sdk_clients = {}  # Cache for CF SDK clients
+
+        self.endpoint_config = self._get_endpoint_config()
+
+        self.token = self.endpoint_config.api_key
+        self.rag_id = self.endpoint_config.index_name
+
+        # TODO: should get this info from somewhere else
+        self.account_id = os.environ.get('CLOUDFLARE_ACCOUNT_ID')
+
+        self.uri = f"accounts/{self.account_id}/autorag/rags/{self.rag_id}/search"
+
+
+    def _get_endpoint_config(self):
+        """Get the Cloudflare SDK endpoint configuration from CONFIG"""
+        endpoint_config = CONFIG.retrieval_endpoints.get(self.endpoint_name)
+        
+        if not endpoint_config:
+            error_msg = f"No configuration found for endpoint {self.endpoint_name}"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+        
+        # Verify this is a Cloudflare SDK endpoint
+        if endpoint_config.db_type != "cloudflare_autorag":
+            error_msg = f"Endpoint {self.endpoint_name} is not a Cloudflare SDK endpoint (type: {endpoint_config.db_type})"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+            
+        return endpoint_config
+    
+    def _get_cf_sdk_client(self) -> AsyncCloudflare:
+        """
+        Get or create a Cloudflare SDK client.
+                    
+        Returns:
+            Cloudflare instance
+        """
+        client_key = f"{self.endpoint_name}"
+        
+        with self._client_lock:
+            if client_key not in self._cf_sdk_clients:
+                logger.debug(f"Creating Cloudflare SDK client for {client_key}")
+                
+                # Initialize the client
+                self._cf_sdk_clients[client_key] = AsyncCloudflare(api_token=self.token)
+                logger.info(f"Created Cloudflare SDK client for {client_key} at {self.uri}")
+                
+                # Test client connection with a simple search
+                try:
+                    logger.debug("Testing connection to Cloudflare SDK")
+                   # self._cf_sdk_clients[client_key].list_collections()
+                    logger.info(f"Connection verified for {client_key}")
+                except Exception as e:
+                    logger.error(f"Failed to connect to Cloudflare SDK at {self.uri}: {str(e)}")
+                    raise
+
+        return self._cf_sdk_clients[client_key]
+
+    async def __get(self, path: str, body: dict) -> httpx.Response:
+        client = self._get_cf_sdk_client()
+
+        return await client.get(
+            path,
+            cast_to=httpx.Response,
+            body=body,
+        )
+
+    async def __post(self, path: str, body: dict) -> httpx.Response:
+        client = self._get_cf_sdk_client()
+
+        resp = await client.post(
+            path,
+            cast_to=httpx.Response,
+            body=body,
+        )
+
+        return resp
+
+    async def __put(self, path: str, body: dict) -> httpx.Response:
+        client = self._get_cf_sdk_client()
+
+        return await client.put(
+            path,
+            cast_to=httpx.Response,
+            body=body,
+        )
+
+    async def deleted_documents_by_site(self, site: str, **kwargs) -> int:
+        raise NotImplementedError("Not implemented yet")
+
+    async def upload_documents(self, documents: List[Dict[str, Any]], **kwargs) -> int:
+        raise NotImplementedError("Not implemented yet")
+
+    async def search(
+        self,
+        query: str,
+        site: Union[str, List[str]],
+        num_results: int = 50,
+        query_params: Optional[Dict[str, Any]] = None,
+        **kwargs
+    ) -> List[List[str]]:
+
+        ranking_options = kwargs.get('ranking_options', {})
+        system_prompt = kwargs.get('system_prompt', None)
+        filters = kwargs.get('filters', None)
+
+        body = {
+            'query': query,
+        }
+
+        if num_results is not None:
+            body['max_num_results'] = num_results
+
+        if ranking_options is not None:
+            body['ranking_options'] = ranking_options
+        
+        if system_prompt is not None:
+            body['system_prompt'] = system_prompt
+
+        success, filters = searchFiltersComparisonFilter.or_else([searchFiltersCompoundFilter]).optional().safe_validate(filters)
+        if success and filters is not None:
+            body['filters'] = filters
+
+        resp = await self.__post(self.uri, body)
+
+        results = resp.json()['result']
+
+        data = results['data']
+
+        def _parse_data_item(item: dict):
+            url = item.get('filename')
+            text_json = ''
+            name = item.get('attributes', {}).get('filename', '')
+            site = ''
+
+            return [url, text_json, name, site]
+
+        return list(map(_parse_data_item, data))
+
+    async def search_by_url(self, url: str, **kwargs) -> Optional[List[str]]:
+        raise NotImplementedError("Not implemented yet")
+
+    async def search_all_sites(
+        self, query: str, num_results: int = 50, **kwargs
+    ) -> List[List[str]]:
+        return await self.search(query, site=[], num_results=num_results, **kwargs)
+
+    async def get_sites(self, **kwargs) -> List[str]:
+        """
+        Get a list of unique site names.
+
+        Returns:
+            List[str]: Sorted list of unique site names
+        """
+        raise NotImplementedError("Not implemented yet")

--- a/code/python/testing/query_retrieval_tests.json
+++ b/code/python/testing/query_retrieval_tests.json
@@ -44,5 +44,14 @@
     "site": "all",
     "num_results": 10,
     "expected_min_results": 1
+  },
+  {
+    "test_type": "query_retrieval",
+    "description": "Test search with Cloudflare AutoRAG",
+    "query": "cloudflare 1.1.1.1 ",
+    "retrieval_backend": "cloudflare_autorag",
+    "site": "all",
+    "num_results": 10,
+    "expected_min_results": 1
   }
 ]

--- a/config/config_retrieval.yaml
+++ b/config/config_retrieval.yaml
@@ -127,3 +127,10 @@ endpoints:
     api_endpoint_env: SNOWFLAKE_ACCOUNT_URL
     index_name: SNOWFLAKE_CORTEX_SEARCH_SERVICE
     db_type: snowflake_cortex_search
+
+  cloudflare_autorag:
+    enabled: true
+    api_key_env: CLOUDFLARE_API_TOKEN
+    api_endpoint_env: CLOUDFLARE_AUTORAG_ENDPOINT
+    index_name: CLOUDFLARE_RAG_ID_ENV
+    db_type: cloudflare_autorag

--- a/docs/nlweb-retrieval.md
+++ b/docs/nlweb-retrieval.md
@@ -62,12 +62,15 @@ These fields are common across most endpoint types:
   - `milvus`
   - `snowflake_cortex_search`
   - `opensearch`
+  - `cloudflare_autorag`
 - **Example**: `db_type: azure_ai_search`
 
 #### `index_name`
-- **Purpose**: The name of the index/collection to use in the database
+- **Purpose**: The name of the index/collection to use in the database.
 - **Type**: String
 - **Example**: `index_name: embeddings1536`
+
+> Note: For `cloudflare_autorag`, this is the id of the AutoRAG instance.
 
 ## Multiple Endpoints
 

--- a/docs/setup-cloudflare-autorag.md
+++ b/docs/setup-cloudflare-autorag.md
@@ -1,0 +1,27 @@
+# Cloudflare AutoRAG
+
+Cloudflare AutoRAG is a service that allows you to build Retrieval-Augmented Generation (RAG) applications using your data, stored on Cloudflare's platform. This guide will help you set up and connect to your Cloudflare AutoRAG instance for use within NLWeb-powered applications.
+
+## Prerequisites
+
+- A Cloudflare account. You can create one at https://www.cloudflare.com/sign-up.
+- An existing AutoRAG instance or the ability to create one. See https://developers.cloudflare.com/autorag/ for further details.
+- An API token with permissions to access the AutoRAG service. See https://developers.cloudflare.com/fundamentals/api/get-started/create-token/
+
+## Use Cloudflare AutoRAG for retrieval
+
+Edit [config_retrieval.yaml](../code/config_retrieval.yaml) and change `write_endpoint` at the top to `write_endpoint: cloudflare_autorag`. Then, in your `.env` file, set the following variables:
+
+* `CLOUDFLARE_API_TOKEN`: Your Cloudflare Account API key. You can generate this token in the Cloudflare dashboard under "Profile" -> "API Tokens". 
+* `CLOUDFLARE_RAG_ID_ENV`: The ID of your AutoRAG instance. This is the name of the AutoRAG as it appears in the Cloudflare dashboard.
+* `CLOUDFLARE_ACCOUNT_ID`: Your Cloudflare Account ID. See [this page](https://developers.cloudflare.com/fundamentals/account/find-account-and-zone-ids/) to find your Account ID.
+
+## Test connectivity
+
+Run from 'python' directory:
+
+```sh
+python code/python/testing/check_connectivity.py
+```
+
+You'll see a three line report on configuration whether configuration has been set correctly for your selected Cloudflare AutoRAG instance.


### PR DESCRIPTION
This PR adds a retrieval provider that connects to [Cloudflare AutoRAG](https://developers.cloudflare.com/autorag/).

The configuration for this provider needs uses the following keys:
```yaml
cloudflare_autorag:
  enabled: true
  api_key_env: CLOUDFLARE_API_TOKEN
  api_endpoint_env: CLOUDFLARE_AUTORAG_ENDPOINT
  index_name: CLOUDFLARE_RAG_ID_ENV
  db_type: cloudflare_autorag
```

It should be noted that `index_name` is used by the newly added provider as the ID of the AutoRAG instance to which NLWeb should make requests to.