### PR TITLE
Corrects returned data in Cloudflare AutoRAG retrieval provider

### DIFF
--- a/code/python/core/retriever.py
+++ b/code/python/core/retriever.py
@@ -85,7 +85,7 @@ _db_type_packages = {
     "elasticsearch": ["elasticsearch[async]>=8,<9"],
     "postgres": ["psycopg", "psycopg[binary]>=3.1.12", "psycopg[pool]>=3.2.0", "pgvector>=0.4.0"],
     "shopify_mcp": ["aiohttp>=3.8.0"],
-    "cloudflare_autorag": ['cloudflare>=4.3.1', "httpx>=0.28.1", "zon>=3.0.0"],
+    "cloudflare_autorag": ['cloudflare>=4.3.1', "httpx>=0.28.1", "zon>=3.0.0", "markdown>=3.8.2", "beautifulsoup4>=4.13.4"],
 }
 
 # Cache for installed packages

--- a/code/python/retrieval_providers/cf_autorag_client.py
+++ b/code/python/retrieval_providers/cf_autorag_client.py
@@ -15,6 +15,30 @@ from cloudflare import AsyncCloudflare
 
 import zon as z
 
+from bs4 import BeautifulSoup
+from markdown import markdown
+import re
+
+def markdown_to_text(markdown_string):
+    """ 
+    Converts a markdown string to plaintext 
+    
+    Taken from https://gist.github.com/lorey/eb15a7f3338f959a78cc3661fbc255fe
+    """
+
+    # md -> html -> text since BeautifulSoup can extract text cleanly
+    html = markdown(markdown_string)
+
+    # remove code snippets
+    html = re.sub(r'<pre>(.*?)</pre>', ' ', html)
+    html = re.sub(r'<code>(.*?)</code >', ' ', html)
+
+    # extract text
+    soup = BeautifulSoup(html, "html.parser")
+    text = ''.join(soup.findAll(text=True))
+
+    return text
+
 logger = get_configured_logger("cloudflare_autorag_client")
 
 searchFiltersComparisonFilter = z.record({
@@ -161,10 +185,20 @@ class CloudflareAutoRAGClient:
             name = file_attributes.get('title', '')
 
             contents = item.get('content', [])
+
+            description = markdown_to_text(''.join(map(lambda c: c['text'], contents)).replace("\n", " ")[:420])
+
             text_json = json.dumps({
-                'attributes': attributes,
-                'contents': contents,
-                'filename': url
+                "@context": "http://schema.org/",
+                "@type": "Product",
+                "@id": "#social-preview",
+                "name": file_attributes.get('title', "Social Preview"),
+                "brand": {
+                    "@type": "Brand",
+                    name: "Cloudflare",
+                },
+                "description": file_attributes.get('description', description), 
+                "image": file_attributes.get('image', ''),
             })
 
             site = url.removeprefix('https://').split('/')[0] # FIXME: this filtering scheme just returns the actual domain, not "section specific" data (like different sections related to different offerings in a documentation website)

--- a/code/python/retrieval_providers/cf_autorag_client.py
+++ b/code/python/retrieval_providers/cf_autorag_client.py
@@ -155,13 +155,23 @@ class CloudflareAutoRAGClient:
         def _parse_data_item(item: dict):
             url: str = item.get('filename')
 
-            contents = item.get('content', [])
-            text_json = json.dumps(contents)
+            attributes = item.get('attributes', {})
+            file_attributes = attributes.get('file', {})
 
-            name = item.get('attributes', {}).get('filename', '')
+            name = file_attributes.get('title', '')
+
+            contents = item.get('content', [])
+            text_json = json.dumps({
+                'attributes': attributes,
+                'contents': contents,
+                'filename': url
+            })
+
             site = url.removeprefix('https://').split('/')[0] # FIXME: this filtering scheme just returns the actual domain, not "section specific" data (like different sections related to different offerings in a documentation website)
 
-            return [url, text_json, name, site]
+            entry =  [url, text_json, name, site]
+
+            return entry
 
         return list(map(_parse_data_item, data))
 


### PR DESCRIPTION
PR #324 introduced [Cloudflare AutoRAG](https://developers.cloudflare.com/autorag/) as a retrieval provider for NLWeb. However, search items returned contained incorrectly formatted data. This PR fixes it.

The main contribution of this PR is to return `text_json` as a Schema.org formatted object.