### PR TITLE
Changes to handle NS_BASE more cleanly

### DIFF
--- a/code/python/core/prompts.py
+++ b/code/python/core/prompts.py
@@ -21,6 +21,10 @@ prompt_runner_logger = get_configured_logger("prompt_runner")
 
 
 BASE_NS = "http://nlweb.ai/base"
+SITE_TAG = "{" + BASE_NS + "}Site"
+PROMPT_TAG = "{" + BASE_NS + "}Prompt"
+PROMPT_STRING_TAG = "{" + BASE_NS + "}promptString"
+RETURN_STRUC_TAG = "{" + BASE_NS + "}returnStruc"
 
 # This file deals with getting the right prompt for a given
 # type, site and prompt-name. 
@@ -194,12 +198,6 @@ def find_prompt(site, item_type, prompt_name):
     if cached_values is not None:
         logger.debug(f"Returning cached prompt for '{prompt_name}'")
         return cached_values
-
-    BASE_NS = "http://nlweb.ai/base"
-    SITE_TAG = "{" + BASE_NS + "}Site"
-    PROMPT_TAG = "{" + BASE_NS + "}Prompt"
-    PROMPT_STRING_TAG = "{" + BASE_NS + "}promptString"
-    RETURN_STRUC_TAG = "{" + BASE_NS + "}returnStruc"
     
     # First, try to find a Site element matching the site parameter
     site_element = None
@@ -271,7 +269,7 @@ def get_prompt_variables_from_file(xml_file_path):
         
         def process_element(element):
             # Check if current element is a promptString
-            if element.tag == '{http://nlweb.ai/base}promptString':
+            if element.tag == PROMPT_STRING_TAG:
                 prompt_text = element.text
                 if prompt_text:
                     variables = extract_variables_from_prompt(prompt_text)

--- a/config/prompts.xml
+++ b/config/prompts.xml
@@ -128,7 +128,7 @@
       <promptString>
         Analyze the following query from the user.
         Is the user asking for only one kind of item or are they asking for multiple kinds of items.
-        If they are asking for multiple kinds of items, construct indepenent queries for each of the 
+        If they are asking for multiple kinds of items, construct independent queries for each of the 
         kinds of items, separated by semicolons. The user's query is: {request.query}.
       </promptString>
       <returnStruc>
@@ -401,11 +401,11 @@
           "memory_request": "The memory request, if any"
         }
       </returnStruc>
-     </Prompt>
+    </Prompt>
 
 
 
- <Prompt ref="ItemMatchingPrompt">
+    <Prompt ref="ItemMatchingPrompt">
       <promptString>
         The user is looking for some details about: {request.item_name} and the users query is: {request.query}.
         Assign a score between 0 and 100 for whether the following item description
@@ -431,7 +431,7 @@
       </returnStruc>
     </Prompt>
 
-        <Prompt ref="RankingPrompt">
+    <Prompt ref="RankingPrompt">
       <promptString>
         Assign a score between 0 and 100 to the following item
         based on how relevant it is to the user's question. Use your knowledge from other sources, about the item, to make a judgement. 


### PR DESCRIPTION
Changes to handle NS_BASE more cleanly - defined multiple times in file and should be defined once at the top.  Plus the value is used verbatim without this constant name.