### PR TITLE
fix: add missing type="module" to index-storage script

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -213,7 +213,7 @@
   </div>
 
   <!-- IndexedDB Storage -->
-  <script src="/static/indexed-storage.js"></script>
+  <script type="module" src="/static/indexed-storage.js"></script>
   
   <script type="module">
     import { UnifiedChatInterface } from '/static/chat-interface-unified.js';

--- a/static/who.html
+++ b/static/who.html
@@ -244,7 +244,7 @@
   </div>
 
   <!-- IndexedDB Storage -->
-  <script src="/static/indexed-storage.js"></script>
+  <script type="module" src="/static/indexed-storage.js"></script>
   
   <script type="module">
     import { ChatUICommon } from '/static/chat-ui-common.js';


### PR DESCRIPTION
`indexed-storage.js` is an es module and without `type="module"`  it throws a syntax error:

```
Uncaught SyntaxError: import declarations may only appear at top level of a module
```

This PR fixes this issue. 