### PR TITLE
Add aggregation_enabled configuration and logic

### DIFF
--- a/code/python/core/config.py
+++ b/code/python/core/config.py
@@ -96,6 +96,7 @@ class NLWebConfig:
     analyze_query_enabled: bool = False  # Enable or disable query analysis
     decontextualize_enabled: bool = True  # Enable or disable decontextualization
     required_info_enabled: bool = True  # Enable or disable required info checking
+    aggregation_enabled: bool = False  # Enable or disable aggregation functionality
     api_keys: Dict[str, str] = field(default_factory=dict)  # API keys for external services
     who_endpoint: str = "http://localhost:8000/who"  # Endpoint for /who requests
 
@@ -467,6 +468,9 @@ class AppConfig:
         # Load required info enabled flag
         required_info_enabled = self._get_config_value(data.get("required_info_enabled"), True)
         
+        # Load aggregation enabled flag
+        aggregation_enabled = self._get_config_value(data.get("aggregation_enabled"), False)
+        
         # Load who_endpoint from config
         who_endpoint = self._get_config_value(data.get("who_endpoint"), "http://localhost:8000/who")
         
@@ -504,6 +508,7 @@ class AppConfig:
             analyze_query_enabled=analyze_query_enabled,
             decontextualize_enabled=decontextualize_enabled,
             required_info_enabled=required_info_enabled,
+            aggregation_enabled=aggregation_enabled,
             api_keys=api_keys,
             who_endpoint=who_endpoint
         )
@@ -613,6 +618,10 @@ class AppConfig:
     def is_required_info_enabled(self) -> bool:
         """Check if required info checking is enabled."""
         return self.nlweb.required_info_enabled if hasattr(self, 'nlweb') else True
+    
+    def is_aggregation_enabled(self) -> bool:
+        """Check if aggregation functionality is enabled."""
+        return self.nlweb.aggregation_enabled if hasattr(self, 'nlweb') else False
     
     def load_sites_config(self, path: str = "sites.xml"):
         """Load site configurations from XML file."""

--- a/code/python/core/fastTrack.py
+++ b/code/python/core/fastTrack.py
@@ -14,6 +14,7 @@ Backwards compatibility is not guaranteed at this time.
 from core.retriever import search
 import core.ranking as ranking
 from misc.logger.logging_config_helper import get_configured_logger
+from core.config import CONFIG
 import asyncio
 
 logger = get_configured_logger("fast_track")
@@ -23,6 +24,12 @@ NO_STANDARD_RETRIEVAL_SITES = ["datacommons", "all", "conv_history", "CricketLen
 
 def site_supports_standard_retrieval(site):
     """Check if a site supports standard vector database retrieval"""
+    
+    # If site is "all" and aggregation is disabled, treat it as supporting standard retrieval
+    if site == "all" and not CONFIG.is_aggregation_enabled():
+        logger.debug("Site is 'all' with aggregation disabled - treating as standard retrieval")
+        return True
+    
     return site not in NO_STANDARD_RETRIEVAL_SITES
 
 class FastTrack:

--- a/config/config_nlweb.yaml
+++ b/config/config_nlweb.yaml
@@ -31,6 +31,10 @@ decontextualize_enabled: true
 # When set to false, the system will not check if required information is present before processing queries
 required_info_enabled: true
 
+# Enable or disable aggregation functionality
+# When set to false, the system will not perform aggregation operations
+aggregation_enabled: false
+
 # Endpoint for /who requests to get relevant sites
 who_endpoint: "https://whotoask.azurewebsites.net/who"
 


### PR DESCRIPTION
- Added aggregation_enabled config attribute to config_nlweb.yaml (default: false)
- Updated config.py to read and expose the new aggregation_enabled setting
- Modified router.py to default to search tool when site="all" and aggregation is disabled
- Updated fastTrack.py to support standard retrieval for site="all" when aggregation is disabled

This allows the system to bypass complex aggregation logic and use simple search when dealing with "all" sites and aggregation is not enabled.