### PR TITLE
fix docker build on debian linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,14 @@ FROM python:3.13-slim AS builder
 
 # Install build dependencies
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends gcc python3-dev && \
+    apt-get install -y --no-install-recommends \
+        gcc \
+        g++ \
+        python3-dev \
+        build-essential \
+        cmake \
+        make \
+        git && \
     pip install --no-cache-dir --upgrade pip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -19,18 +26,22 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Stage 2: Runtime stage
 FROM python:3.13-slim
 
-# Apply security updates
+# Install runtime dependencies and apply security updates
 RUN apt-get update && \
-   apt-get install -y --no-install-recommends --only-upgrade \
-       $(apt-get --just-print upgrade | grep "^Inst" | grep -i securi | awk '{print $2}') && \
-   apt-get clean && \
-   rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends \
+        libgomp1 \
+        libgcc-s1 && \
+    apt-get install -y --no-install-recommends --only-upgrade \
+        $(apt-get --just-print upgrade | grep "^Inst" | grep -i securi | awk '{print $2}') && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 # Create a non-root user and set permissions
 RUN groupadd -r nlweb && \
     useradd -r -g nlweb -d /app -s /bin/bash nlweb && \
+    mkdir -p /app/data /app/data/json_with_embeddings && \
     chown -R nlweb:nlweb /app
 
 USER nlweb
@@ -38,10 +49,15 @@ USER nlweb
 # Copy application code
 COPY code/ /app/
 COPY static/ /app/static/
+COPY config/ /app/config/
 
 # Copy installed packages from builder stage
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Ensure data directories exist and have proper permissions
+RUN mkdir -p /app/data/json_with_embeddings && \
+    chmod -R 755 /app/data
 
 # Expose the port the app runs on
 EXPOSE 8000


### PR DESCRIPTION
Fixes an error while building the docker image on debian linux:

```bash
19.16 Successfully built sgmllib3k
19.16 Failed to build chroma-hnswlib
19.29 error: failed-wheel-build-for-install
19.29 
19.29 × Failed to build installable wheels for some pyproject.toml based projects
19.29 ╰─> chroma-hnswlib
------
Dockerfile:17
```