### PR TITLE
Fix result sorting and improve WHO handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -452,3 +452,8 @@ old_code/set_keys.sh
 .vscode/settings.json
 /static/ta/ba
 static/.DS_Store
+
+# Deployment archives
+*_deploy_*.zip
+nlwm_deploy_*.zip
+agentfinder_deploy_*.zip

--- a/code/python/core/config.py
+++ b/code/python/core/config.py
@@ -355,6 +355,7 @@ class AppConfig:
             data = {
                 "port": 8080,
                 "static_directory": "./static",
+                "homepage": "static/index.html",
                 "server": {}
             }
         
@@ -362,6 +363,7 @@ class AppConfig:
         self.port: int = self._get_config_value(data.get("port"), 8080)
         self.static_directory: str = self._get_config_value(data.get("static_directory"), "./static")
         self.mode: str = self._get_config_value(data.get("mode"), "production")
+        self.homepage: str = self._get_config_value(data.get("homepage"), "static/index.html")
         
         # Keep static directory relative to config directory, not base output directory
         if not os.path.isabs(self.static_directory):

--- a/code/python/core/query_analysis/query_rewrite.py
+++ b/code/python/core/query_analysis/query_rewrite.py
@@ -31,10 +31,13 @@ class QueryRewrite(PromptRunner):
         Rewrite the decontextualized query into simpler keyword queries.
         The results are stored in handler.rewritten_queries.
         """
-        # Wait for decontextualization to complete since we need the decontextualized query
+        # Skip query rewrite for sites that don't support standard retrieval
         if not site_supports_standard_retrieval(self.handler.site):
+            self.handler.rewritten_queries = [self.handler.query]
             await self.handler.state.precheck_step_done(self.STEP_NAME)
+            return
 
+        # Wait for decontextualization to complete since we need the decontextualized query
         await self.handler.state._decon_event.wait()
 
         

--- a/code/python/core/whoHandler.py
+++ b/code/python/core/whoHandler.py
@@ -1,7 +1,9 @@
 from core.baseHandler import NLWebHandler
 from core.retriever import search
 from core.whoRanking import WhoRanking
+from core.llm import ask_llm
 from misc.logger.logging_config_helper import get_configured_logger
+import asyncio
 
 # Who handler is work in progress for answering questions about who
 # might be able to answer a given query
@@ -9,6 +11,7 @@ from misc.logger.logging_config_helper import get_configured_logger
 logger = get_configured_logger("who_handler")
 
 DEFAULT_NLWEB_ENDPOINT = "https://nlwm.azurewebsites.net/ask"
+ENABLE_QUERY_FANOUT = False
 
 class WhoHandler (NLWebHandler) :
 
@@ -71,46 +74,74 @@ class WhoHandler (NLWebHandler) :
         # Call parent class's send_message with modified message
         await super().send_message(message)
 
+  
+    async def whoQueryRewrite(self):
+        ans_struc = {
+          "rewritten_queries": ["query1", "query2", "query3", "query4", "query5"],
+          "query_count": "Number of queries generated (1-5)"
+        }
+    
+        prompt = f"""
+        You are helping to rewrite a complex search query into simpler keyword queries for a very simple
+        vector embedding search, which can easily get distracted.
+        The search engine works best with short, focused queries containing important keywords.
+        
+        Take the following query and break it down into up to 5 simpler search queries.
+        Each query should:
+        - Contain no more than 3 words
+        - Focus on the most important keywords and concepts
+        - Be diverse to cover different aspects of the original query
+        - Use only essential nouns, adjectives, or product terms
+        - Avoid common words like "for", "the", "some", "are", "that", "would", "be"
+        
+        The original query is: {self.query}"""
+        response = await ask_llm(prompt, ans_struc, level="high", 
+                                query_params=self.http_handler.query_params, timeout=10)
+                         
+        # Extract the rewritten queries from the response
+        rewritten_queries = response.get("rewritten_queries", [])
+
+        valid_queries = [q for q in rewritten_queries if q and isinstance(q, str) and q.strip()]
+        valid_queries.append(self.query)
+        print(valid_queries)
+        return valid_queries
+    
+    async def whoRetrieveInt(self, query):
+        items = await search(
+                query, 
+                site='nlweb_sites',  # Use the sites collection
+                query_params=self.query_params,
+                num_results=20
+            )
+        for item in items:
+            if (item not in self.final_retrieved_items):
+                self.final_retrieved_items.append(item) 
+            
+  
     async def runQuery(self):
 
         try:
-            # Always use general search with nlweb_sites
-            logger.info("Using general search method with site=nlweb_sites for who query")
-            
-            # Search using the special nlweb_sites collection
-            items = await search(
-                self.query, 
-                site='nlweb_sites',  # Use the sites collection
-                query_params=self.query_params,
-                num_results=25
-            )
-            self.final_retrieved_items = items
-            print(f"\n=== WHO HANDLER: Retrieved {len(items)} items from nlweb_sites ===")
-            
-            # Print just the site names
-            print("\nRetrieved sites:")
-            site_names = []
-            for item in items:
-                if isinstance(item, tuple) and len(item) >= 3:
-                    name = item[2]  # name is the third element
-                    site_names.append(name)
-            
-            # Print unique site names
-            unique_sites = sorted(set(site_names))
-            for i, name in enumerate(unique_sites, 1):
-                print(f"  {i}. {name}")
-            print("=" * 60)
-            
-            logger.debug(f"Who retrieval complete: {len(self.final_retrieved_items)} items retrieved")
-            
-            # Use simplified WHO ranking - no decontextualization needed
+            # Send begin-nlweb-response message at the start
+            await self.message_sender.send_begin_response()
+            tasks = []
+            if (ENABLE_QUERY_FANOUT):
+                queries = await self.whoQueryRewrite()
+            else:
+                queries = [self.query]
+            for query in queries:
+                tasks.append(asyncio.create_task(self.whoRetrieveInt(query)))
+            await asyncio.gather(*tasks, return_exceptions=True)       
+       
             self.ranker = WhoRanking(self, self.final_retrieved_items)
             await self.ranker.do()
             
-            logger.info("Who ranking completed")
-            logger.debug("Who ranking complete")
-            return self.return_value  
-                
+            # Send end-nlweb-response message at the end
+            await self.message_sender.send_end_response()
+
+            return [msg.to_dict() for msg in self.messages]
+
         except Exception as e:
+            # Send end-nlweb-response even on error
+            await self.message_sender.send_end_response(error=True)
             raise
         

--- a/code/python/webserver/mcp_wrapper.py
+++ b/code/python/webserver/mcp_wrapper.py
@@ -53,18 +53,19 @@ class MCPHandler:
         is_notification = request_id is None
         
         logger.info(f"MCP request: method={method}, id={request_id}, is_notification={is_notification}")
-        print(f"=== MCP REQUEST: method={method}, id={request_id}, initialized={self.initialized}, handler_id={id(self)} ===")
-        
+        # Commented out verbose logging
+        # print(f"=== MCP REQUEST: method={method}, id={request_id}, initialized={self.initialized}, handler_id={id(self)} ===")
+
         try:
             # Route based on method
             if method == "initialize":
                 result = await self.handle_initialize(params)
-                print(f"=== INITIALIZE COMPLETE, sending response ===")
+                # print(f"=== INITIALIZE COMPLETE, sending response ===")
             elif method == "initialized" or method == "notifications/initialized":
                 # This is a notification, no response needed
                 self.initialized = True
                 logger.info("MCP server initialized")
-                print(f"=== SERVER MARKED AS INITIALIZED ===")
+                # print(f"=== SERVER MARKED AS INITIALIZED ===")
                 if not is_notification:
                     result = {"status": "ok"}
                 else:
@@ -76,7 +77,7 @@ class MCPHandler:
                 logger.info(f"tools/list called, initialized={self.initialized}")
                 result = await self.handle_tools_list(params)
             elif method == "tools/call":
-                print(f"=== TOOLS/CALL: initialized={self.initialized} ===")
+                # print(f"=== TOOLS/CALL: initialized={self.initialized} ===")
                 # Remove the initialization check - MCP clients might not send initialize first
                 # if not self.initialized:
                 #     raise Exception("Server not initialized")
@@ -292,14 +293,15 @@ class MCPHandler:
         arguments = params.get("arguments", {})
         
         logger.info(f"MCP tool call: {tool_name} with args: {arguments}")
-        print(f"=== TOOL CALL: {tool_name} ===")
-        print(f"Arguments: {json.dumps(arguments, indent=2)}")
+        # Commented out verbose logging
+        # print(f"=== TOOL CALL: {tool_name} ===")
+        # print(f"Arguments: {json.dumps(arguments, indent=2)}")
         
         if tool_name == "ask":
             # Handle the main query tool
             query = arguments.get("query", "")
-            print(f"=== PROCESSING ASK TOOL ===")
-            print(f"Query: {query}")
+            # print(f"=== PROCESSING ASK TOOL ===")
+            # print(f"Query: {query}")
             sites = arguments.get("site", [])
             generate_mode = arguments.get("generate_mode", "list")
             
@@ -309,10 +311,9 @@ class MCPHandler:
             if sites:
                 query_params["site"] = sites if isinstance(sites, list) else [sites]
             query_params["generate_mode"] = [generate_mode] if generate_mode else ["list"]
-            
-            print(f"=== QUERY PARAMS BEING PASSED ===")
-            print(f"query_params: {query_params}")
-            
+            # print(f"=== QUERY PARAMS BEING PASSED ===")
+            # print(f"query_params: {query_params}")
+
             # Create a response accumulator
             response_content = []
             
@@ -331,14 +332,14 @@ class MCPHandler:
             capture_chunk = ChunkCapture()
             
             # Process the query using NLWebHandler with a timeout
-            print(f"=== CREATING NLWebHandler ===")
-            print(f"Query params: {query_params}")
+            # print(f"=== CREATING NLWebHandler ===")
+            # print(f"Query params: {query_params}")
             handler = NLWebHandler(query_params, capture_chunk)
             try:
-                print(f"=== CALLING handler.runQuery() ===")
+                # print(f"=== CALLING handler.runQuery() ===")
                 # Add a 30-second timeout for MCP requests
                 result = await asyncio.wait_for(handler.runQuery(), timeout=30.0)
-                print(f"=== HANDLER RETURNED: {result} ===")
+                # print(f"=== HANDLER RETURNED: {result} ===")
             except asyncio.TimeoutError:
                 logger.warning("MCP tool call timed out after 30 seconds")
                 return {
@@ -533,10 +534,11 @@ async def handle_mcp_request(query_params, body, send_response, send_chunk, stre
         if body:
             try:
                 request_data = json.loads(body)
-                print(f"\n=== INCOMING MCP REQUEST ===")
-                print(f"Body: {json.dumps(request_data, indent=2)}")
-                print(f"===========================\n")
-                
+                # Commented out verbose logging
+                # print(f"\n=== INCOMING MCP REQUEST ===")
+                # print(f"Body: {json.dumps(request_data, indent=2)}")
+                # print(f"===========================\n")
+
                 # Validate JSON-RPC format
                 if "jsonrpc" not in request_data:
                     request_data["jsonrpc"] = "2.0"

--- a/code/python/webserver/routes/api.py
+++ b/code/python/webserver/routes/api.py
@@ -85,9 +85,8 @@ async def handle_streaming_ask(request: web.Request, query_params: Dict[str, Any
             from core.baseHandler import NLWebHandler
             handler = NLWebHandler(query_params, wrapper)
             await handler.runQuery()
-        
-        # Send completion message
-        await wrapper.write_stream({"message_type": "complete", "sender_info": {"id": "system", "name": "NLWeb"}})
+
+        # Handler already sends end-nlweb-response, no need for additional complete message
         
     except Exception as e:
         logger.error(f"Error in streaming ask handler: {e}", exc_info=True)
@@ -159,9 +158,8 @@ async def who_handler(request: web.Request) -> web.Response:
                 # Run the who handler with streaming
                 handler = WhoHandler(query_params, wrapper)
                 await handler.runQuery()
-                
-                # Send completion message
-                await wrapper.write_stream({"message_type": "complete", "sender_info": {"id": "system", "name": "NLWeb"}})
+
+                # Handler already sends end-nlweb-response, no need for additional complete message
                 
             except Exception as e:
                 logger.error(f"Error in streaming who handler: {e}", exc_info=True)

--- a/code/python/webserver/routes/chat.py
+++ b/code/python/webserver/routes/chat.py
@@ -1488,9 +1488,7 @@ async def sse_message_handler(request: web.Request) -> web.StreamResponse:
             # Send timeout notification
             await response.write(b'data: {"type": "timeout", "message": "Response timeout"}\n\n')
 
-        # Send final completion
-        print(f"[SSE] Sending completion message")
-        await response.write(b'data: {"message_type": "complete"}\n\n')
+        # No longer send complete message - end-nlweb-response is sent by handler
 
         print(f"[SSE] Returning response")
         return response

--- a/config/config_nlweb.yaml
+++ b/config/config_nlweb.yaml
@@ -40,7 +40,7 @@ aggregation_enabled: true
 who_endpoint_enabled: true
 
 # Endpoint for /who requests to get relevant sites
-who_endpoint: "https://whotoask.azurewebsites.net/who"
+who_endpoint: "https://agentfinder.azurewebsites.net/who"
 
 # Headers for HTTP requests
 headers:

--- a/config/config_retrieval.yaml
+++ b/config/config_retrieval.yaml
@@ -136,7 +136,7 @@ endpoints:
 
   # Shopify MCP endpoint for product search across Shopify stores
   shopify:
-    enabled: false
+    enabled: true
     db_type: shopify_mcp
     # Note: mcp_endpoint will be dynamically set based on the site being queried
     name: Shopify MCP Search

--- a/config/config_webserver.yaml
+++ b/config/config_webserver.yaml
@@ -5,8 +5,10 @@ static_directory: ../static
 # if development, various config params can be overridden with query params
 # obviously, this cannot be allowed in production.
 # in testing mode, exceptions are raised instead of being caught for better error visibility
-mode: development # or production or testing. 
+mode: development # or production or testing.
 
+# Default homepage path
+homepage: static/who.html
 
 # Additional optional configurations
 server:

--- a/config/prompts.xml
+++ b/config/prompts.xml
@@ -185,7 +185,6 @@
         Provide a short description of the item that is relevant to the user's question, without mentioning the user's question.
         Provide an explanation of the relevance of the item to the user's question, without mentioning the user's question or the score or explicitly mentioning the term relevance.
         If the score is below 75, in the description, include the reason why it is still relevant.
-        The description you generate should be in the same language as the item's description.
           
         The user's question is: {request.query}. The item's description is {item.description}
       </promptString>
@@ -205,7 +204,6 @@
         If the score is above 50, provide a short description of the item highlighting the relevance to the user's question, without mentioning the user's question.
         Provide an explanation of the relevance of the item to the user's question, without mentioning the user's question or the score or explicitly mentioning the term relevance.
         If the score is below 75, in the description, include the reason why it is still relevant.
-        The description you generate should be in the same language as the item's description.
           
 
         The user's question is: \"{request.query}\". The item's description in schema.org format is \"{item.description}\".
@@ -770,8 +768,6 @@
           
           Consider that this result is being compared against results from multiple different sites,
           so factor in the credibility and relevance of the source site as well.
-
-          The description you generate should be in the same language as the item's description.
           
           The user's question is: "{request.query}". 
           The item's description is: "{item.description}".

--- a/config/statistics_templates.txt
+++ b/config/statistics_templates.txt
@@ -1,44 +1,86 @@
-
-
-1. What is the <variable> in the xyz county {"county": "name of county", "variable": "variable being asked for"} [highlight]
-2. Which <place> has the highest <variable> {"place": "name of place", "variable": "variable being asked for"} [ranking]
-3. What is the correlation between <variable1> and <variable2> across <place-type> {"variable1": "first variable", "variable2": "second variable", "place-type": "place type like US counties"} [scatter]
-4. How does <variable> in <county A> compare to <county B>? {"county_a": "name", "county_b": "name", "variable": "variable"} [bar]
-5. What's the difference in <variable> between <county A> and <county B>? {"county_a": "name", "county_b": "name", "variable": "variable"} [bar]
-6. What are the top <N> counties by <variable>? {"n": "number", "variable": "variable"} [ranking]
-7. What are the bottom <N> counties by <variable>? {"n": "number", "variable": "variable"} [ranking]
-8. Where does <county> rank in terms of <variable>? {"county": "name", "variable": "variable"} [ranking]
-9. What's the average <variable> across all counties? {"variable": "variable"} [map]
-10. What's the median <variable> across all counties? {"variable": "variable"} [map]
-11. What counties are above/below the average <variable>? {"variable": "variable", "comparison": "above or below"} [ranking]
-12. Which counties have <variable> greater than <threshold>? {"variable": "variable", "threshold": "number"} [ranking]
-13. Which counties have both <variable1> above <threshold1> and <variable2> below <threshold2>? {"variable1": "variable", "threshold1": "number", "variable2": "variable", "threshold2": "number"} [scatter]
-14. How has <variable> changed in <county> from <year1> to <year2>? {"variable": "variable", "county": "name", "year1": "number", "year2": "number"} [line]
-15. Which county had the largest increase/decrease in <variable> between <year1> and <year2>? {"variable": "variable", "year1": "number", "year2": "number", "direction": "increase or decrease"} [ranking]
-16. What's the ratio of <variable1> to <variable2> in <county>? {"variable1": "variable", "variable2": "variable", "county": "name"} [highlight]
-17. Which counties have the highest <variable1> per <variable2>? {"variable1": "variable", "variable2": "variable"} [ranking]
-18. What percentile is <county> in for <variable>? {"county": "name", "variable": "variable"} [ranking]
-19. Which counties are in the top/bottom <X>% for <variable>? {"percentage": "number", "variable": "variable", "position": "top or bottom"} [ranking]
-20. Which counties are outliers in both <variable1> and <variable2>? {"variable1": "variable", "variable2": "variable"} [scatter]
-21. What's the relationship between population size and <variable>? {"variable": "variable"} [scatter]
-22. What's the growth rate of <variable> in <county> over the past <N> years? {"variable": "variable", "county": "name", "years": "number"} [line]
-23. Which counties have declining <variable> over time? {"variable": "variable"} [line]
-24. What's the percentage of <variable1> relative to <variable2> in <county>? {"variable1": "variable", "variable2": "variable", "county": "name"} [highlight]
-25. Which counties have similar demographic profiles to <county>? {"county": "name"} [scatter]
-26. What counties have <variable> within <X>% of the state average? {"variable": "variable", "percentage": "number"} [ranking]
-27. Which counties are consistently in the top/bottom <N> for <variable> across multiple years? {"n": "number", "variable": "variable", "position": "top or bottom"} [line]
-28. What's the trend for <variable> across all counties over the last <N> years? {"variable": "variable", "years": "number"} [line]
-29. Which counties have the most volatile <variable> over time? {"variable": "variable"} [line]
-30. What counties have both high <variable1> and low <variable2>? {"variable1": "variable", "variable2": "variable"} [scatter]
-31. Which counties are underperforming/overperforming relative to their population size? {"metric": "variable"} [scatter]
-32. What's the standard deviation of <variable> across counties? {"variable": "variable"} [map]
-33. Which counties have <variable> values more than <N> standard deviations from the mean? {"variable": "variable", "std_devs": "number"} [map]
-34. What's the range (min to max) of <variable> across all counties? {"variable": "variable"} [bar]
-35. Which counties have the most balanced demographics across multiple variables? {"variables": "list of variables"} [ranking]
-36. What counties experienced the biggest year-over-year change in <variable>? {"variable": "variable"} [ranking]
-37. Which counties have <variable> closest to the national/state median? {"variable": "variable"} [ranking]
-38. What's the distribution of <variable> across counties (quartiles)? {"variable": "variable"} [map]
-39. Which counties are improving/declining faster than the average rate for <variable>? {"variable": "variable", "direction": "improving or declining"} [ranking]
-40. What counties have unusual ratios between <variable1> and <variable2> compared to similar-sized places? {"variable1": "variable", "variable2": "variable"} [scatter]
-41. Which counties would be good matches for <county> based on <criteria>? {"county": "name", "criteria": "list of variables"} [ranking]
-
+[
+  {
+    "template": "What is the <variable> in the <place>",
+    "extract": {
+      "score": "score",
+      "variable": "variable being asked for",
+      "place": "name of place",
+      "chartTitle": "The title of the chart"
+    },
+    "action": {
+      "type": "highlight",
+      "params": ["place", "variable"]
+    }
+  },
+  {
+    "template": "Which <placeType> in <place> has the highest <variable>",
+    "extract": {
+      "score": "score",
+      "place": "name of containing place",
+      "variable": "variable being asked for",
+      "placeType": "type of place (like county, etc.)",
+      "chartTitle": "The title of the chart"
+    },
+    "action": {
+      "type": "ranking",
+      "params": ["place", "placeType", "variable"]
+    }
+  },
+  {
+    "template": "What is the correlation between <variable1> and <variable2> across <placeType> in <place>",
+    "extract": {
+      "score": "score",
+      "variable1": "first variable",
+      "variable2": "second variable",
+      "place": "containing place",
+      "placeType": "place type like US counties",
+      "chartTitle": "The title of the chart"
+    },
+    "action": {
+      "type": "scatter",
+      "params": ["variable1", "variable2", "placeType"]
+    }
+  },
+  {
+    "template": "How does <variable> in <place1> compare to <place2>?",
+    "extract": {
+      "score": "score",
+      "place1": "name of place",
+      "place2": "name of place",
+      "variable": "variable",
+      "chartTitle": "The title of the chart"
+    },
+    "action": {
+      "type": "bar",
+      "params": ["variable", "place1", "place2"]
+    }
+  },
+  {
+    "template": "Which <placeType> in <place> has the lowest <variable>",
+    "extract": {
+      "score": "score",
+      "place": "name of containing place",
+      "variable": "variable being asked for",
+      "placeType": "type of place (like county, etc.)",
+      "chartTitle": "The title of the chart"
+    },
+    "action": {
+      "type": "ranking",
+      "params": ["place", "variable"]
+    }
+  },
+  {
+    "template": "Show me <variable> across <placeType> in <containingPlace>",
+    "extract": {
+      "score": "score",
+      "variable": "variable",
+      "placeType": "type of place",
+      "containingPlace": "The containing place, implicit or explicit",
+      "chartTitle": "The title of the chart"
+    },
+    "action": {
+      "type": "map",
+      "params": ["variable", "placeType"]
+    }
+  }
+]

--- a/static/chat-interface-unified.js
+++ b/static/chat-interface-unified.js
@@ -1078,16 +1078,27 @@ export class UnifiedChatInterface {
 
     // Handle result messages specially - append the DOM element
     if (data.message_type === 'result' && data._domElement) {
+      // Validate that _domElement is a safe DOM element we created
+      if (!(data._domElement instanceof Element) || data._domElement.tagName !== 'DIV') {
+        console.error('Invalid DOM element in result message');
+        return;
+      }
+
       // Find or create the main search-results container
       let mainContainer = textDiv.querySelector('.search-results');
       if (!mainContainer) {
         // First result - append the whole container
-        textDiv.appendChild(data._domElement);
-        mainContainer = data._domElement;
+        // Clone the node to ensure it's safe
+        const safeElement = data._domElement.cloneNode(true);
+        textDiv.appendChild(safeElement);
+        mainContainer = safeElement;
       } else {
         // Subsequent results - move children to existing container
         while (data._domElement.firstChild) {
-          mainContainer.appendChild(data._domElement.firstChild);
+          // Clone each child before appending to ensure safety
+          const safeChild = data._domElement.firstChild.cloneNode(true);
+          data._domElement.removeChild(data._domElement.firstChild);
+          mainContainer.appendChild(safeChild);
         }
       }
 

--- a/static/chat-ui-common.js
+++ b/static/chat-ui-common.js
@@ -506,8 +506,25 @@ export class ChatUICommon {
           const statsContainer = document.createElement('div');
           statsContainer.className = 'statistics-result-container';
           statsContainer.style.cssText = 'display: block; margin: 15px 0; padding: 15px; background-color: #f8f9fa; border-radius: 8px; min-height: 400px; clear: both;';
-          // This is trusted HTML from backend for Data Commons visualizations
-          statsContainer.innerHTML = htmlContent;
+
+          // Use DOMPurify to sanitize the HTML content if available
+          if (typeof DOMPurify !== 'undefined') {
+            // Sanitize the HTML content to prevent XSS attacks
+            const sanitizedHTML = DOMPurify.sanitize(htmlContent, {
+              ALLOWED_TAGS: ['div', 'span', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+                             'ul', 'ol', 'li', 'table', 'thead', 'tbody', 'tr', 'td', 'th',
+                             'a', 'img', 'strong', 'em', 'code', 'pre', 'br', 'hr'],
+              ALLOWED_ATTR: ['class', 'id', 'style', 'href', 'src', 'alt', 'title',
+                             'width', 'height', 'colspan', 'rowspan'],
+              ALLOW_DATA_ATTR: false
+            });
+            statsContainer.innerHTML = sanitizedHTML;
+          } else {
+            // Fallback to safe text content if DOMPurify is not available
+            console.warn('DOMPurify not available, using safe text fallback');
+            statsContainer.textContent = 'Statistics display requires DOMPurify for security. Please reload the page.';
+          }
+
           bubble.appendChild(statsContainer);
         }
         break;

--- a/static/chat-ui-common.js
+++ b/static/chat-ui-common.js
@@ -506,6 +506,7 @@ export class ChatUICommon {
           const statsContainer = document.createElement('div');
           statsContainer.className = 'statistics-result-container';
           statsContainer.style.cssText = 'display: block; margin: 15px 0; padding: 15px; background-color: #f8f9fa; border-radius: 8px; min-height: 400px; clear: both;';
+          // This is trusted HTML from backend for Data Commons visualizations
           statsContainer.innerHTML = htmlContent;
           bubble.appendChild(statsContainer);
         }

--- a/static/chat-ui-common.js
+++ b/static/chat-ui-common.js
@@ -26,6 +26,16 @@ export class ChatUICommon {
   }
 
   /**
+   * Escape HTML special characters to prevent XSS
+   */
+  escapeHtml(str) {
+    if (str == null) return '';
+    const div = document.createElement('div');
+    div.textContent = String(str);
+    return div.innerHTML;
+  }
+
+  /**
    * Render multiple items/results
    */
   renderItems(items) {
@@ -283,13 +293,13 @@ export class ChatUICommon {
             const href = `/?site=${encodedSite}&query=${encodedQuery}`;
             // Add comma inside the link for better spacing, except for last item
             const siteName = index < array.length - 1 ? `${site.name},` : site.name;
-            return `<a href="${href}" target="_blank" style="color: #0066cc; text-decoration: none; margin-right: 6px;">${siteName}</a>`;
+            return `<a href="${href}" target="_blank" style="color: #0066cc; text-decoration: none; margin-right: 6px;">${this.escapeHtml(siteName)}</a>`;
           }).join(' ');
           messageContent = `Searching: ${siteLinks}\n\n`;
           bubble.innerHTML = messageContent + this.renderItems(allResults);
         } else if (data.content) {
           // Old format fallback
-          messageContent = `Searching: ${data.content}\n\n`;
+          messageContent = `Searching: ${this.escapeHtml(data.content)}\n\n`;
           bubble.innerHTML = messageContent + this.renderItems(allResults);
         }
         break;
@@ -298,7 +308,7 @@ export class ChatUICommon {
         // Display the decontextualized query if different from original
         if (data.decontextualized_query && data.original_query && 
             data.decontextualized_query !== data.original_query) {
-          const decontextMsg = `<div style="font-style: italic; color: #666; margin-bottom: 10px;">Query interpreted as: "${data.decontextualized_query}"</div>`;
+          const decontextMsg = `<div style="font-style: italic; color: #666; margin-bottom: 10px;">Query interpreted as: "${this.escapeHtml(data.decontextualized_query)}"</div>`;
           messageContent = messageContent + decontextMsg;
           bubble.innerHTML = messageContent + this.renderItems(allResults);
         }
@@ -332,7 +342,7 @@ export class ChatUICommon {
         
       case 'nlws':
         if (data.answer && typeof data.answer === 'string') {
-          messageContent = data.answer + '\n\n';
+          messageContent = this.escapeHtml(data.answer) + '\n\n';
         }
         if (data.items && Array.isArray(data.items)) {
           allResults = data.items;
@@ -396,7 +406,7 @@ export class ChatUICommon {
         
       case 'ask_user':
         if (data.content) {
-          messageContent += data.content + '\n';
+          messageContent += this.escapeHtml(data.content) + '\n';
           bubble.innerHTML = messageContent + this.renderItems(allResults);
         }
         break;
@@ -424,7 +434,7 @@ export class ChatUICommon {
         // Handle query analysis which may include decontextualized query
         if (data.decontextualized_query && data.original_query && 
             data.decontextualized_query !== data.original_query) {
-          const decontextMsg = `<div style="font-style: italic; color: #666; margin-bottom: 10px;">Query interpreted as: "${data.decontextualized_query}"</div>`;
+          const decontextMsg = `<div style="font-style: italic; color: #666; margin-bottom: 10px;">Query interpreted as: "${this.escapeHtml(data.decontextualized_query)}"</div>`;
           messageContent = messageContent + decontextMsg;
           bubble.innerHTML = messageContent + this.renderItems(allResults);
         }

--- a/static/dropdown-example.html
+++ b/static/dropdown-example.html
@@ -8,7 +8,10 @@
     <!-- Include the dropdown chat CSS -->
     <link rel="stylesheet" href="common-chat-styles.css">
     <link rel="stylesheet" href="nlweb-dropdown-chat.css">
-    
+
+    <!-- Include DOMPurify for HTML sanitization -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.6/purify.min.js" integrity="sha512-H+rglffZ6f5gF7UJgvH4Naa+fGCgjrHKMgoFOGmcPTRwR6oILo5R+gtzNrpDp7iMV3udbymBVjkeZGNz1Em4rQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
     <!-- Page-specific styles -->
     <style>
         body {

--- a/static/index.html
+++ b/static/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>NLWeb Multi-Chat</title>
+  <title>NLWeb Chat</title>
   <link rel="icon" type="image/png" href="/static/favicon.png">
   <link rel="stylesheet" href="/static/common-chat-styles.css">
   <link rel="stylesheet" href="/static/chat-page-styles.css">

--- a/static/index.html
+++ b/static/index.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/png" href="/static/favicon.png">
   <link rel="stylesheet" href="/static/common-chat-styles.css">
   <link rel="stylesheet" href="/static/chat-page-styles.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.6/purify.min.js" integrity="sha512-H+rglffZ6f5gF7UJgvH4Naa+fGCgjrHKMgoFOGmcPTRwR6oILo5R+gtzNrpDp7iMV3udbymBVjkeZGNz1Em4rQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </head>
 <body>
   <div class="app-container">

--- a/static/site-sample-queries.js
+++ b/static/site-sample-queries.js
@@ -23,24 +23,24 @@ export const SITE_SAMPLE_QUERIES = {
     "Best fruit based dessert recipes for summer entertaining and picnics",
     "Neapolitan style pizza dough recipe with overnight cold fermentation method"
   ],
-  "datacommons": [
-    "What is the population growth rate of California counties since 2010",
-    "Compare median household income across all states in the northeast region",
-    "Crime statistics and trends in major US cities over the past decade"
-  ],
+ // "datacommons": [
+  //  "What is the population growth rate of California counties since 2010",
+ //   "Compare median household income across all states in the northeast region",
+ //   "Crime statistics and trends in major US cities over the past decade"
+ // ],
   "imdb": [
-    "Best science fiction movies released in 2023 with high audience ratings",
-    "Top rated TV shows in the mystery thriller genre from recent years",
-    "Complete list of Christopher Nolan movies ranked by box office performance"
+    "Best science fiction movies not featuring aliens",
+    "Movies about cooking, eating and food, set in a family context",
+    "Movies that portray AI in a good light"
   ],
   "kettl.co": [
     "High quality Japanese green tea varieties for daily morning consumption",
     "Ceremonial grade matcha powder for traditional tea ceremony preparation",
     "Essential tea brewing accessories for preparing authentic Japanese teas at home"
   ],
-  "masuhome.com": [
-    "Traditional Japanese home decor items for creating zen living spaces",
-    "Minimalist furniture pieces inspired by Japanese interior design principles",
-    "Japanese style lighting fixtures for creating warm ambient atmosphere indoors"
+  "hebbarskitchen": [
+    "Alternate dosa batters",
+    "diabetic friendly south indian snacks",
+    "Udipi-chinese fusion recipes"
   ]
 };

--- a/static/who.html
+++ b/static/who.html
@@ -275,7 +275,6 @@
         this.eventSource = null;
         this.allResults = []; // Accumulate all results for re-sorting
         this.aiResponses = []; // Keep AI responses separate
-        this.queryHistory = []; // Track query history for context
 
         // Initialize UI helper
         this.uiHelper = new ChatUICommon({
@@ -332,34 +331,18 @@
         if (!query || this.isProcessing) return;
 
         this.isProcessing = true;
+        this.hasReceivedBeginMessage = false;  // Track if we received begin-nlweb-response
+        this.hasReceivedEndMessage = false;    // Track if we received end-nlweb-response
         this.queryButton.disabled = true;
         this.queryButton.textContent = 'Searching...';
-        
-        // Add current query to history (will be added after successful response)
-        const currentQuery = query;
-        
-        // Show query in results with previous queries for context
+
+        // Show query in results
         this.resultsContainer.innerHTML = '';
-        
-        // Display conversation history
-        if (this.queryHistory.length > 0) {
-          const historyDiv = document.createElement('div');
-          historyDiv.style.cssText = 'margin-bottom: 20px; padding: 10px; background: #f9f9f9; border-radius: 8px;';
-          
-          this.queryHistory.forEach((q, idx) => {
-            const queryDiv = document.createElement('div');
-            queryDiv.style.cssText = 'margin-bottom: 8px; color: #666;';
-            queryDiv.innerHTML = `<strong>Previous Q${idx + 1}:</strong> ${this.escapeHtml(q)}`;
-            historyDiv.appendChild(queryDiv);
-          });
-          
-          this.resultsContainer.appendChild(historyDiv);
-        }
-        
+
         // Display current query
         const currentQueryDiv = document.createElement('div');
         currentQueryDiv.style.cssText = 'margin-bottom: 20px; padding: 12px; background: #e3f2fd; border-radius: 8px; font-weight: 500;';
-        currentQueryDiv.innerHTML = `<strong>Current Query:</strong> ${this.escapeHtml(currentQuery)}`;
+        currentQueryDiv.innerHTML = `<strong>Current Query:</strong> ${this.escapeHtml(query)}`;
         this.resultsContainer.appendChild(currentQueryDiv);
         
         // Add loading indicator
@@ -386,17 +369,11 @@
             this.eventSource.close();
           }
 
-          // Create URL with query parameters including previous queries
+          // Create URL with query parameters
           const params = new URLSearchParams({
             query: query,
             streaming: 'true'  // Use streaming mode
           });
-          
-          // Add previous queries for context (limit to last 3 queries)
-          if (this.queryHistory.length > 0) {
-            const recentQueries = this.queryHistory.slice(-3);
-            params.append('prev_queries', JSON.stringify(recentQueries));
-          }
 
           const url = `/who?${params.toString()}`;
           
@@ -423,8 +400,7 @@
               
               // Handle different message types
               if (data.message_type === 'complete') {
-                // Stream is complete - add query to history
-                this.queryHistory.push(currentQuery);
+                // Stream is complete
                 // Clear the input for next query
                 this.queryInput.value = '';
                 this.cleanup();  // Use cleanup to properly reset state
@@ -452,9 +428,16 @@
           };
           
           this.eventSource.onerror = (error) => {
-            console.error('EventSource error:', error);
-            this.handleError('Connection error occurred');
-            this.eventSource.close();
+            // Only show error if we started receiving data but didn't get a proper end message
+            // If we never got a begin message, it's a connection failure
+            // If we got a begin but no end, the stream was interrupted
+            if (!this.hasReceivedBeginMessage || (this.hasReceivedBeginMessage && !this.hasReceivedEndMessage)) {
+              console.error('EventSource error:', error);
+              this.handleError('Connection error occurred');
+            }
+            if (this.eventSource) {
+              this.eventSource.close();
+            }
             this.isProcessing = false;  // Reset processing flag
             this.queryButton.disabled = false;
             this.queryButton.textContent = 'Search';
@@ -475,9 +458,17 @@
           return;
         }
 
-        if (message.message_type === 'complete' || message.message_type === 'end-nlweb-response') {
+        if (message.message_type === 'begin-nlweb-response') {
+          this.hasReceivedBeginMessage = true;
+          console.log('Received begin-nlweb-response');
+          return;
+        }
+
+        if (message.message_type === 'end-nlweb-response') {
+          this.hasReceivedEndMessage = true;
+          console.log('Received end-nlweb-response');
           this.cleanup();
-          
+
           // Check if no results were received
           if (this.allResults.length === 0 && this.aiResponses.length === 0) {
             this.resultsContainer.innerHTML = `


### PR DESCRIPTION
## Summary
- Implement score-based result sorting in frontend - results display immediately then resort by score
- Fix WHO handler SSE protocol with proper begin/end messages
- Add configurable homepage and remove legacy return_value system

## Changes

### Frontend Result Sorting
- Modified `processMessageByType` to only render items from current message, not accumulated results
- Separated DOM creation from appending logic for cleaner architecture  
- Store DOM elements (not HTML strings) for efficient resorting
- Results appear immediately as they arrive, then get resorted by score when `end-nlweb-response` is received

### WHO Handler Improvements
- Fixed EventSource connection errors by adding proper `begin-nlweb-response` and `end-nlweb-response` messages
- Added server-side logging to show sites that were retrieved but not returned (sorted by score)
- Removed query history functionality from who.html

### Backend Cleanup
- Added configurable homepage attribute to webserver configuration (config_webserver.yaml)
- Removed legacy return_value system from baseHandler (fixes #353)
- Suppressed verbose MCP tool call logging
- Fixed Python bytecode caching issues

## Test Plan
- [ ] Test result sorting with queries that return results in random score order
- [ ] Verify WHO handler works without EventSource errors
- [ ] Confirm homepage configuration works correctly
- [ ] Check that MCP logging is properly suppressed
- [ ] Verify no duplicate results appear after sorting

🤖 Generated with [Claude Code](https://claude.com/claude-code)