### PR TITLE
ci: fix TruffleHog "BASE and HEAD are the same" failure on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,6 @@ jobs:
         uses: trufflesecurity/trufflehog@v3.95.2
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event.before || github.event.pull_request.base.sha }}
+          head: ${{ github.event.after || github.event.pull_request.head.sha }}
           extra_args: --only-verified


### PR DESCRIPTION
## Problem

The `Secrets Scan` job fails on every push to `main`. The TruffleHog step is configured as:

```yaml
base: ${{ github.event.repository.default_branch }}   # = main
head: HEAD
```

On a `push` event, `HEAD` *is* `main`, so `base == head`. TruffleHog has nothing to diff and exits 1 with:

> BASE and HEAD commits are the same. TruffleHog won't scan anything.

This is a config issue, not a real secret detection — the scan covers zero commits. Example failing run: https://github.com/nlweb-ai/NLWeb/actions/runs/27296850476

## Fix

Pass the actual commit range for each event type:

- **push** → `github.event.before` … `github.event.after`
- **pull_request** → `github.event.pull_request.base.sha` … `github.event.pull_request.head.sha`

The `||` fallback selects the right pair since the unused fields are empty for the other event type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)